### PR TITLE
Usable on iPhone11 Pro Max

### DIFF
--- a/PopcornTime/Base.lproj/iOS.storyboard
+++ b/PopcornTime/Base.lproj/iOS.storyboard
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
+    <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -13,22 +12,18 @@
         <scene sceneID="NkY-91-raC">
             <objects>
                 <viewController storyboardIdentifier="TermsOfServiceViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="W38-k8-hA6" customClass="TermsOfServiceViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="FZd-ZO-Irr"/>
-                        <viewControllerLayoutGuide type="bottom" id="7Ii-tp-y2y"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="5IW-JT-dCe">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Jj-db-XOh">
-                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jvO-Rz-kpD" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1349.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1265.6666666666667"/>
                                         <subviews>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Apo-KL-gYE">
-                                                <rect key="frame" x="10" y="0.0" width="355" height="1269.5"/>
+                                                <rect key="frame" x="10" y="0.0" width="394" height="1185.6666666666667"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <string key="text">Your Acceptance
 
@@ -58,7 +53,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1f8-za-H7e" customClass="BorderButton" customModule="PopcornTime" customModuleProvider="target">
-                                                <rect key="frame" x="197.5" y="1289.5" width="157.5" height="40"/>
+                                                <rect key="frame" x="217" y="1205.6666666666667" width="177" height="40"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="40" id="lcZ-zT-e8d"/>
                                                 </constraints>
@@ -81,7 +76,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rCq-rW-7AR" customClass="BorderButton" customModule="PopcornTime" customModuleProvider="target">
-                                                <rect key="frame" x="20" y="1289.5" width="157.5" height="40"/>
+                                                <rect key="frame" x="20" y="1205.6666666666667" width="177" height="40"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="40" id="4qC-h4-oJn"/>
                                                 </constraints>
@@ -138,10 +133,11 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         <color key="backgroundColor" red="0.10980392156862745" green="0.10980392156862745" blue="0.10980392156862745" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="1Jj-db-XOh" firstAttribute="top" secondItem="5IW-JT-dCe" secondAttribute="topMargin" id="8Qc-Rx-rMa"/>
-                            <constraint firstAttribute="trailing" secondItem="1Jj-db-XOh" secondAttribute="trailing" id="kBW-GQ-9F2"/>
-                            <constraint firstItem="1Jj-db-XOh" firstAttribute="leading" secondItem="5IW-JT-dCe" secondAttribute="leading" id="lOL-lS-aX1"/>
+                            <constraint firstItem="FEY-Hf-qBX" firstAttribute="trailing" secondItem="1Jj-db-XOh" secondAttribute="trailing" id="kBW-GQ-9F2"/>
+                            <constraint firstItem="1Jj-db-XOh" firstAttribute="leading" secondItem="FEY-Hf-qBX" secondAttribute="leading" id="lOL-lS-aX1"/>
                             <constraint firstAttribute="bottomMargin" secondItem="1Jj-db-XOh" secondAttribute="bottom" id="wCN-GP-7FW"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="FEY-Hf-qBX"/>
                     </view>
                     <navigationItem key="navigationItem" title="Terms Of Service" id="QPL-7d-wRG"/>
                 </viewController>
@@ -184,32 +180,32 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
             <objects>
                 <tableViewController id="Cmi-E7-hrT" customClass="DownloadViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="80" sectionHeaderHeight="28" sectionFooterHeight="28" id="rIO-CZ-HwI">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.1176470588" green="0.1176470588" blue="0.1176470588" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="separatorColor" red="0.2274509804" green="0.2274509804" blue="0.2274509804" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="downloadCell" id="EYr-iJ-Msm" customClass="DownloadTableViewCell" customModule="PopcornTime" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="80"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="80"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="EYr-iJ-Msm" id="sqr-m3-wWX">
-                                    <rect key="frame" x="0.0" y="0.0" width="341" height="79.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383" height="80"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Episode Placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="8Cd-2u-5wp">
-                                            <rect key="frame" x="10" y="10" width="106" height="59.5"/>
+                                            <rect key="frame" x="10" y="10" width="106.66666666666667" height="60"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="8Cd-2u-5wp" secondAttribute="height" multiplier="16:9" id="rbB-Ri-dbG"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="U5H-1P-kVz">
-                                            <rect key="frame" x="126" y="38" width="0.0" height="0.0"/>
+                                            <rect key="frame" x="126.66666666666667" y="38" width="0.0" height="0.0"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="qCE-Ru-S2v">
-                                            <rect key="frame" x="126" y="42" width="0.0" height="0.0"/>
+                                            <rect key="frame" x="126.66666666666667" y="42" width="0.0" height="0.0"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
                                             <nil key="highlightedColor"/>
@@ -237,32 +233,32 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="downloadDetailCell" id="1tJ-uT-Fl6" customClass="DownloadDetailTableViewCell" customModule="PopcornTime" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="108" width="375" height="80"/>
+                                <rect key="frame" x="0.0" y="108" width="414" height="80"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="1tJ-uT-Fl6" id="MGf-Ps-z28">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="79.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="80"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Episode Placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="Hbp-Gf-udP">
-                                            <rect key="frame" x="10" y="10" width="106" height="59.5"/>
+                                            <rect key="frame" x="10" y="10" width="106.66666666666667" height="60"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="Hbp-Gf-udP" secondAttribute="height" multiplier="16:9" id="7IG-yb-oeM"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="9eR-rp-aY4">
-                                            <rect key="frame" x="126" y="38" width="0.0" height="0.0"/>
+                                            <rect key="frame" x="126.66666666666667" y="38" width="0.0" height="0.0"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="L1I-5C-cc6">
-                                            <rect key="frame" x="126" y="42" width="0.0" height="0.0"/>
+                                            <rect key="frame" x="126.66666666666667" y="42" width="0.0" height="0.0"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ynz-iA-l57" customClass="DownloadButton" customModule="PopcornTime" customModuleProvider="target">
-                                            <rect key="frame" x="330" y="26" width="30" height="28"/>
+                                            <rect key="frame" x="369" y="26" width="30" height="28"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
                                             <connections>
                                                 <action selector="accessoryButtonPressed:" destination="1tJ-uT-Fl6" eventType="primaryActionTriggered" id="AD5-QK-YFW"/>
@@ -306,7 +302,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             </connections>
                         </barButtonItem>
                         <segmentedControl key="titleView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="0z5-df-jt5">
-                            <rect key="frame" x="94" y="7" width="187" height="30"/>
+                            <rect key="frame" x="110.66666666666669" y="6" width="193" height="32"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <segments>
                                 <segment title="Queue"/>
@@ -330,38 +326,38 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
             <objects>
                 <tableViewController id="2vI-2e-CfB" customClass="DownloadDetailViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="80" sectionHeaderHeight="28" sectionFooterHeight="28" id="fi8-Cm-HoW">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.1176470588" green="0.1176470588" blue="0.1176470588" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="separatorColor" red="0.2274509804" green="0.2274509804" blue="0.2274509804" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="cell" id="SvY-DJ-DhZ" customClass="DownloadDetailTableViewCell" customModule="PopcornTime" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="80"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="80"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SvY-DJ-DhZ" id="GMN-GA-SjV">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="79.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="80"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Episode Placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="HZv-gL-hGK">
-                                            <rect key="frame" x="10" y="10" width="106" height="59.5"/>
+                                            <rect key="frame" x="10" y="10" width="106.66666666666667" height="60"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="HZv-gL-hGK" secondAttribute="height" multiplier="16:9" id="yGT-Z0-Kah"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gFu-cv-Wgn">
-                                            <rect key="frame" x="126" y="38" width="0.0" height="0.0"/>
+                                            <rect key="frame" x="126.66666666666667" y="38" width="0.0" height="0.0"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="18"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="88R-NB-2hF">
-                                            <rect key="frame" x="126" y="42" width="0.0" height="0.0"/>
+                                            <rect key="frame" x="126.66666666666667" y="42" width="0.0" height="0.0"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="39f-k5-AWm" customClass="DownloadButton" customModule="PopcornTime" customModuleProvider="target">
-                                            <rect key="frame" x="330" y="26" width="30" height="28"/>
+                                            <rect key="frame" x="369" y="26" width="30" height="28"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
                                             <connections>
                                                 <action selector="accessoryButtonPressed:" destination="SvY-DJ-DhZ" eventType="primaryActionTriggered" id="5bC-ux-AXk"/>
@@ -408,7 +404,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                 <navigationController id="xXj-Fy-MDS" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" systemItem="downloads" id="sOj-1h-WSq"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="I0j-LM-d75">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -426,7 +422,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                     <tabBarItem key="tabBarItem" title="Movies" image="Movies Off" selectedImage="Movies On" id="Fp3-rP-ViE"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="x2p-EW-YdI">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -445,7 +441,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                     <tabBarItem key="tabBarItem" title="Shows" image="Shows Off" selectedImage="Shows On" id="xj0-2s-5ug"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="5Qd-BT-yVX">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -464,7 +460,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                     <tabBarItem key="tabBarItem" title="Watchlist" image="Watchlist Off" selectedImage="Watchlist On" id="xew-qA-F0u"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="N4b-ZC-Bbb">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -480,28 +476,24 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="8M5-CN-kJo">
             <objects>
                 <viewController storyboardIdentifier="PreloadTorrentViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="bpF-BT-5hX" customClass="PreloadTorrentViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="edO-5f-6wJ"/>
-                        <viewControllerLayoutGuide type="bottom" id="wYT-2i-xjG"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="H3I-zp-t3P">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Movie Placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="h1W-dr-Kz3">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yOp-a8-DP1" userLabel="Dimmer View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OPG-db-ELp">
-                                        <rect key="frame" x="167" y="206" width="41.5" height="24"/>
+                                        <rect key="frame" x="186" y="320.66666666666669" width="42" height="24"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s1m-ma-4D9" userLabel="Container View">
-                                        <rect key="frame" x="50.5" y="270" width="274" height="127"/>
+                                        <rect key="frame" x="70" y="384.66666666666669" width="274" height="127"/>
                                         <subviews>
                                             <progressView hidden="YES" opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QOI-Cw-eqb">
                                                 <rect key="frame" x="15" y="0.0" width="244" height="2"/>
@@ -519,7 +511,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 seeds" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CQx-bV-2GM" userLabel="Seeds Label">
-                                                <rect key="frame" x="106.5" y="51" width="61" height="21"/>
+                                                <rect key="frame" x="106.66666666666666" y="51" width="61" height="21"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="21" id="Yda-H5-cJF"/>
                                                 </constraints>
@@ -539,7 +531,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VY7-iX-HO6">
-                                                <rect key="frame" x="71.5" y="0.0" width="131" height="20"/>
+                                                <rect key="frame" x="71.666666666666657" y="0.0" width="131" height="20"/>
                                                 <subviews>
                                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="yJF-49-UV7">
                                                         <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
@@ -549,7 +541,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                         </constraints>
                                                     </activityIndicatorView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Processing..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ggd-Zr-efA">
-                                                        <rect key="frame" x="32" y="-0.5" width="99" height="21"/>
+                                                        <rect key="frame" x="32" y="-0.66666666666668561" width="99" height="21"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -600,16 +592,17 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="yOp-a8-DP1" firstAttribute="width" secondItem="H3I-zp-t3P" secondAttribute="width" id="8KI-af-N3Y"/>
-                            <constraint firstItem="yOp-a8-DP1" firstAttribute="leading" secondItem="H3I-zp-t3P" secondAttribute="leading" id="Ag1-rn-TLU"/>
+                            <constraint firstItem="yOp-a8-DP1" firstAttribute="leading" secondItem="oUF-U2-0hw" secondAttribute="leading" id="Ag1-rn-TLU"/>
                             <constraint firstItem="h1W-dr-Kz3" firstAttribute="width" secondItem="H3I-zp-t3P" secondAttribute="width" id="Cbt-fd-mcq"/>
-                            <constraint firstItem="h1W-dr-Kz3" firstAttribute="centerX" secondItem="H3I-zp-t3P" secondAttribute="centerX" id="K0f-yB-2nM"/>
+                            <constraint firstItem="h1W-dr-Kz3" firstAttribute="centerX" secondItem="oUF-U2-0hw" secondAttribute="centerX" id="K0f-yB-2nM"/>
                             <constraint firstItem="h1W-dr-Kz3" firstAttribute="height" secondItem="H3I-zp-t3P" secondAttribute="height" id="OCL-pm-MVb"/>
                             <constraint firstAttribute="topMargin" secondItem="yOp-a8-DP1" secondAttribute="top" id="SbK-de-jqY"/>
                             <constraint firstItem="h1W-dr-Kz3" firstAttribute="centerY" secondItem="H3I-zp-t3P" secondAttribute="centerY" id="ZrD-dZ-LUj"/>
                             <constraint firstAttribute="bottomMargin" secondItem="yOp-a8-DP1" secondAttribute="bottom" id="cTk-Vi-WDr"/>
-                            <constraint firstAttribute="trailing" secondItem="yOp-a8-DP1" secondAttribute="trailing" id="fNw-bf-uyF"/>
+                            <constraint firstItem="oUF-U2-0hw" firstAttribute="trailing" secondItem="yOp-a8-DP1" secondAttribute="trailing" id="fNw-bf-uyF"/>
                             <constraint firstItem="yOp-a8-DP1" firstAttribute="height" secondItem="H3I-zp-t3P" secondAttribute="height" id="nwm-wz-PJQ"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="oUF-U2-0hw"/>
                     </view>
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
                     <connections>
@@ -629,18 +622,14 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="XH9-g0-Ecf">
             <objects>
                 <viewController id="nTw-hc-21n" customClass="UpNextViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="74g-Mr-kfW"/>
-                        <viewControllerLayoutGuide type="bottom" id="Mjt-fP-phJ"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="2Zu-u6-Xum">
+                    <view key="view" contentMode="scaleToFill" id="2Zu-u6-Xum">
                         <rect key="frame" x="0.0" y="0.0" width="337" height="101"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tqr-Tl-pzK">
-                                <rect key="frame" x="0.0" y="0.0" width="337" height="101"/>
+                                <rect key="frame" x="0.0" y="44" width="337" height="57"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="PWH-Dg-ot5">
-                                    <rect key="frame" x="0.0" y="0.0" width="337" height="101"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="337" height="57"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Episode Placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="8rb-09-gi9">
@@ -705,12 +694,12 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="30" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMi-84-3dl">
-                                            <rect key="frame" x="238.5" y="32.5" width="39" height="36"/>
+                                            <rect key="frame" x="238.66666666666663" y="10.666666666666664" width="39" height="36"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="30"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EXy-2O-Vnc" customClass="BlurButton" customModule="PopcornTime" customModuleProvider="target">
-                                            <rect key="frame" x="91.5" y="33" width="35" height="35"/>
+                                            <rect key="frame" x="91.666666666666671" y="33" width="35" height="35"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="35" id="028-tC-mP2"/>
                                                 <constraint firstAttribute="height" constant="35" id="FjS-dR-cZR"/>
@@ -722,7 +711,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                             </connections>
                                         </button>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2jU-jk-pgD" customClass="BlurButton" customModule="PopcornTime" customModuleProvider="target">
-                                            <rect key="frame" x="31.5" y="33" width="35" height="35"/>
+                                            <rect key="frame" x="31.666666666666671" y="33" width="35" height="35"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="35" id="MX1-Ms-Xoc"/>
                                                 <constraint firstAttribute="width" constant="35" id="Xau-1B-snC"/>
@@ -758,10 +747,11 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="Tqr-Tl-pzK" firstAttribute="top" secondItem="2Zu-u6-Xum" secondAttribute="topMargin" id="5Z7-fn-dfU"/>
-                            <constraint firstAttribute="trailing" secondItem="Tqr-Tl-pzK" secondAttribute="trailing" id="c0S-JY-ldL"/>
-                            <constraint firstItem="Tqr-Tl-pzK" firstAttribute="leading" secondItem="2Zu-u6-Xum" secondAttribute="leading" id="frw-Mo-RII"/>
+                            <constraint firstItem="xth-5z-Rf0" firstAttribute="trailing" secondItem="Tqr-Tl-pzK" secondAttribute="trailing" id="c0S-JY-ldL"/>
+                            <constraint firstItem="Tqr-Tl-pzK" firstAttribute="leading" secondItem="xth-5z-Rf0" secondAttribute="leading" id="frw-Mo-RII"/>
                             <constraint firstAttribute="bottomMargin" secondItem="Tqr-Tl-pzK" secondAttribute="bottom" id="r3d-me-RY4"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="xth-5z-Rf0"/>
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="boolean" keyPath="translatesAutoresizingMaskIntoConstraints" value="NO"/>
                         </userDefinedRuntimeAttributes>
@@ -784,29 +774,25 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="mIN-jE-T6A">
             <objects>
                 <viewController storyboardIdentifier="PCTPlayerViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="aWK-kY-qxl" customClass="PCTPlayerViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="2mO-rA-gES"/>
-                        <viewControllerLayoutGuide type="bottom" id="gaf-Hg-0hh"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="tai-PT-4SR">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <view key="view" contentMode="scaleToFill" id="tai-PT-4SR">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WgY-wG-9qK">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="External Playback Indicator" translatesAutoresizingMaskIntoConstraints="NO" id="z1M-Y1-LyX">
-                                        <rect key="frame" x="122" y="238.5" width="131" height="90"/>
+                                        <rect key="frame" x="141.66666666666666" y="353" width="130.99999999999997" height="90"/>
                                         <color key="tintColor" white="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="AirPlay" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ewU-Yj-c2n">
-                                        <rect key="frame" x="157" y="238.5" width="61" height="24"/>
+                                        <rect key="frame" x="176.66666666666666" y="353" width="61" height="24"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <color key="textColor" white="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This video is playing on a different screen." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="axl-sn-e2J">
-                                        <rect key="frame" x="27" y="262.5" width="321.5" height="20.5"/>
+                                        <rect key="frame" x="46.333333333333343" y="377" width="321.33333333333326" height="20.333333333333314"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="0.5" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
@@ -824,9 +810,8 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                     <constraint firstItem="ewU-Yj-c2n" firstAttribute="centerX" secondItem="axl-sn-e2J" secondAttribute="centerX" id="pcf-Tk-Off"/>
                                 </constraints>
                             </view>
-                            <view multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cBH-Pg-tUV">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <view multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cBH-Pg-tUV">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
                                     <outletCollection property="gestureRecognizers" destination="xbd-Wq-rlE" appends="YES" id="M2D-Oj-pfV"/>
@@ -834,12 +819,12 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </connections>
                             </view>
                             <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="skb-F0-Olz">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="671"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="900"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" cocoaTouchSystemColor="darkTextColor"/>
                             </imageView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AJi-AG-mCt">
-                                <rect key="frame" x="-337" y="420" width="337" height="101"/>
+                                <rect key="frame" x="-337" y="615" width="337" height="101"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="337" id="Vfq-8Z-fAG"/>
                                     <constraint firstAttribute="height" constant="101" id="g9U-1F-ovc"/>
@@ -849,19 +834,19 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </connections>
                             </containerView>
                             <visualEffectView hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2j1-2U-WUF" userLabel="Tooltip View">
-                                <rect key="frame" x="16" y="518" width="343" height="28"/>
+                                <rect key="frame" x="20" y="713" width="374" height="28"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="21L-sO-myr">
-                                    <rect key="frame" x="0.0" y="0.0" width="343" height="28"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="374" height="28"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Slide your finger up to adjust the scrubbing rate." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uI3-Ys-VBR">
-                                            <rect key="frame" x="44.5" y="0.0" width="254.5" height="14"/>
+                                            <rect key="frame" x="59.666666666666671" y="0.0" width="254.66666666666663" height="14"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hi-Speed Scrubbing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gMU-tx-wlv">
-                                            <rect key="frame" x="118" y="14" width="107" height="14"/>
+                                            <rect key="frame" x="133.66666666666666" y="14" width="107" height="14"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
@@ -885,21 +870,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </userDefinedRuntimeAttributes>
                             </visualEffectView>
                             <visualEffectView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n24-lm-kCE" userLabel="Player Controls View">
-                                <rect key="frame" x="16" y="546" width="343" height="111"/>
+                                <rect key="frame" x="20" y="741" width="374" height="111"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="RNP-by-fW2">
-                                    <rect key="frame" x="0.0" y="0.0" width="343" height="111"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="374" height="111"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4nb-Ja-SmR" customClass="ProgressBar" customModule="PopcornTime" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="56"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="56"/>
                                             <subviews>
                                                 <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progressViewStyle="bar" progress="1" translatesAutoresizingMaskIntoConstraints="NO" id="iHL-oa-F1v">
-                                                    <rect key="frame" x="20" y="27.5" width="303" height="2.5"/>
+                                                    <rect key="frame" x="20" y="27.333333333333371" width="334" height="2.6666666666666679"/>
                                                     <color key="progressTintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <color key="trackTintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </progressView>
                                                 <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="FDw-kG-pGE" customClass="BarSlider" customModule="PopcornTime" customModuleProvider="target">
-                                                    <rect key="frame" x="18" y="13" width="307" height="31"/>
+                                                    <rect key="frame" x="18" y="13" width="338" height="31"/>
                                                     <color key="minimumTrackTintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <color key="maximumTrackTintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <connections>
@@ -912,7 +897,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                     </connections>
                                                 </slider>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--:--" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aPB-D9-3oY">
-                                                    <rect key="frame" x="283" y="43.5" width="40" height="20"/>
+                                                    <rect key="frame" x="314" y="43.666666666666629" width="40" height="20"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="cKD-6s-EQF"/>
                                                     </constraints>
@@ -1008,14 +993,14 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                             </connections>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mue-SG-NfQ" userLabel="Loading View">
-                                            <rect key="frame" x="119" y="13" width="105" height="30"/>
+                                            <rect key="frame" x="134.66666666666666" y="13" width="105" height="30"/>
                                             <subviews>
                                                 <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="aYm-2k-7oM">
                                                     <rect key="frame" x="0.0" y="5" width="20" height="20"/>
                                                     <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </activityIndicatorView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LQM-cz-rEk">
-                                                    <rect key="frame" x="30" y="4.5" width="75" height="21"/>
+                                                    <rect key="frame" x="30" y="4.6666666666666288" width="75" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
@@ -1032,7 +1017,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                             </constraints>
                                         </view>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iEu-QD-PlZ" userLabel="Play">
-                                            <rect key="frame" x="160" y="76" width="23" height="25"/>
+                                            <rect key="frame" x="175.66666666666666" y="76" width="23" height="25"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="25" id="5Ta-Le-skz"/>
                                                 <constraint firstAttribute="width" constant="23" id="NBF-Bw-afL"/>
@@ -1044,7 +1029,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                             </connections>
                                         </button>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PG1-42-8ja" userLabel="Forward">
-                                            <rect key="frame" x="203" y="77.5" width="32" height="22"/>
+                                            <rect key="frame" x="218.66666666666666" y="77.666666666666629" width="32" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="32" id="ilr-YH-azy"/>
                                                 <constraint firstAttribute="height" constant="22" id="qKQ-KO-gz7"/>
@@ -1057,7 +1042,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                             </connections>
                                         </button>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NZb-Sa-ls8" userLabel="Subtitles">
-                                            <rect key="frame" x="299" y="77.5" width="24" height="22"/>
+                                            <rect key="frame" x="330" y="77.666666666666629" width="24" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="22" id="a59-rF-cNd"/>
                                                 <constraint firstAttribute="width" constant="24" id="igy-zp-tpB"/>
@@ -1069,7 +1054,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                             </connections>
                                         </button>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CTd-dM-nvd" userLabel="Airplay">
-                                            <rect key="frame" x="20" y="77.5" width="24" height="22"/>
+                                            <rect key="frame" x="20" y="77.666666666666629" width="24" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="24" id="INt-2f-oT3"/>
                                                 <constraint firstAttribute="height" constant="22" id="SjV-Tk-hWi"/>
@@ -1081,7 +1066,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                             </connections>
                                         </button>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VaM-2V-VMO" userLabel="Rewind">
-                                            <rect key="frame" x="108" y="77.5" width="32" height="22"/>
+                                            <rect key="frame" x="123.66666666666666" y="77.666666666666629" width="32" height="22"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="32" id="aD0-Rc-Egp"/>
                                                 <constraint firstAttribute="height" constant="22" id="kqN-SX-2hp"/>
@@ -1207,7 +1192,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </variation>
                             </visualEffectView>
                             <visualEffectView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hga-si-ZlZ" userLabel="Video Controls View">
-                                <rect key="frame" x="16" y="30" width="87" height="46"/>
+                                <rect key="frame" x="20" y="54" width="87" height="46"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="QNl-2h-iN5">
                                     <rect key="frame" x="0.0" y="0.0" width="87" height="46"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1254,7 +1239,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </userDefinedRuntimeAttributes>
                             </visualEffectView>
                             <visualEffectView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t48-WK-t6X" userLabel="Volume Controls View">
-                                <rect key="frame" x="313" y="30" width="46" height="46"/>
+                                <rect key="frame" x="348" y="54" width="46" height="46"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ka4-Gf-X3F">
                                     <rect key="frame" x="0.0" y="0.0" width="46" height="46"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1308,22 +1293,27 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         <constraints>
                             <constraint firstItem="Hga-si-ZlZ" firstAttribute="leading" secondItem="tai-PT-4SR" secondAttribute="leadingMargin" id="1sf-EV-FUd"/>
                             <constraint firstItem="n24-lm-kCE" firstAttribute="leading" secondItem="tai-PT-4SR" secondAttribute="leadingMargin" id="5Sd-dA-Tbm"/>
-                            <constraint firstItem="WgY-wG-9qK" firstAttribute="leading" secondItem="tai-PT-4SR" secondAttribute="leading" id="Dio-Nq-tWb"/>
-                            <constraint firstItem="2j1-2U-WUF" firstAttribute="centerX" secondItem="tai-PT-4SR" secondAttribute="centerX" id="G3G-5q-uvk"/>
+                            <constraint firstItem="cBH-Pg-tUV" firstAttribute="bottom" secondItem="rw8-0Q-geh" secondAttribute="bottom" id="Cyh-oz-2ez"/>
+                            <constraint firstItem="WgY-wG-9qK" firstAttribute="leading" secondItem="rw8-0Q-geh" secondAttribute="leading" id="Dio-Nq-tWb"/>
+                            <constraint firstItem="2j1-2U-WUF" firstAttribute="centerX" secondItem="rw8-0Q-geh" secondAttribute="centerX" id="G3G-5q-uvk"/>
                             <constraint firstItem="WgY-wG-9qK" firstAttribute="top" secondItem="tai-PT-4SR" secondAttribute="top" id="GdY-iX-Qwb"/>
                             <constraint firstItem="n24-lm-kCE" firstAttribute="top" secondItem="AJi-AG-mCt" secondAttribute="bottom" constant="25" id="Kgz-yL-XLo"/>
-                            <constraint firstItem="t48-WK-t6X" firstAttribute="top" secondItem="2mO-rA-gES" secondAttribute="bottom" constant="10" id="Kpy-Bx-bKw"/>
+                            <constraint firstItem="t48-WK-t6X" firstAttribute="top" secondItem="rw8-0Q-geh" secondAttribute="top" constant="10" id="Kpy-Bx-bKw"/>
+                            <constraint firstItem="rw8-0Q-geh" firstAttribute="trailing" secondItem="cBH-Pg-tUV" secondAttribute="trailing" id="S3j-Yd-k6z"/>
                             <constraint firstAttribute="bottom" secondItem="WgY-wG-9qK" secondAttribute="bottom" id="Sup-nn-TmS"/>
-                            <constraint firstAttribute="leading" secondItem="AJi-AG-mCt" secondAttribute="trailing" id="chK-ay-lLW"/>
+                            <constraint firstItem="rw8-0Q-geh" firstAttribute="leading" secondItem="AJi-AG-mCt" secondAttribute="trailing" id="chK-ay-lLW"/>
                             <constraint firstAttribute="trailingMargin" secondItem="n24-lm-kCE" secondAttribute="trailing" id="dJ5-2V-wAo"/>
                             <constraint firstItem="2j1-2U-WUF" firstAttribute="bottom" secondItem="n24-lm-kCE" secondAttribute="top" id="f2s-SX-ydU"/>
-                            <constraint firstItem="Hga-si-ZlZ" firstAttribute="top" secondItem="2mO-rA-gES" secondAttribute="bottom" constant="10" id="gb4-bb-ie7"/>
-                            <constraint firstItem="n24-lm-kCE" firstAttribute="centerX" secondItem="tai-PT-4SR" secondAttribute="centerX" id="iNk-3n-dss"/>
-                            <constraint firstAttribute="trailing" secondItem="WgY-wG-9qK" secondAttribute="trailing" id="nwm-De-pXx"/>
+                            <constraint firstItem="Hga-si-ZlZ" firstAttribute="top" secondItem="rw8-0Q-geh" secondAttribute="top" constant="10" id="gb4-bb-ie7"/>
+                            <constraint firstItem="n24-lm-kCE" firstAttribute="centerX" secondItem="rw8-0Q-geh" secondAttribute="centerX" id="iNk-3n-dss"/>
+                            <constraint firstItem="cBH-Pg-tUV" firstAttribute="leading" secondItem="rw8-0Q-geh" secondAttribute="leading" id="iWT-VM-BeX"/>
+                            <constraint firstItem="rw8-0Q-geh" firstAttribute="trailing" secondItem="WgY-wG-9qK" secondAttribute="trailing" id="nwm-De-pXx"/>
                             <constraint firstAttribute="trailingMargin" secondItem="t48-WK-t6X" secondAttribute="trailing" id="oMB-0P-Lgb"/>
                             <constraint firstItem="2j1-2U-WUF" firstAttribute="width" secondItem="n24-lm-kCE" secondAttribute="width" id="vuu-Jh-FFZ"/>
-                            <constraint firstItem="gaf-Hg-0hh" firstAttribute="top" secondItem="n24-lm-kCE" secondAttribute="bottom" constant="10" id="z8S-1U-WYw"/>
+                            <constraint firstItem="rw8-0Q-geh" firstAttribute="top" secondItem="cBH-Pg-tUV" secondAttribute="top" id="wKr-ew-UDh"/>
+                            <constraint firstItem="rw8-0Q-geh" firstAttribute="bottom" secondItem="n24-lm-kCE" secondAttribute="bottom" constant="10" id="z8S-1U-WYw"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="rw8-0Q-geh"/>
                     </view>
                     <toolbarItems/>
                     <connections>
@@ -1383,48 +1373,44 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="9Cn-Xr-PRQ">
             <objects>
                 <viewController storyboardIdentifier="CastPlayerViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="9g2-2Z-FUe" customClass="CastPlayerViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="hZT-7H-YbI"/>
-                        <viewControllerLayoutGuide type="bottom" id="RAX-OI-ffA"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="uYT-27-WQP">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="VEc-Xt-eHf">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="clipsToBounds" value="YES"/>
                                 </userDefinedRuntimeAttributes>
                             </imageView>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zpx-Rj-7KQ">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="F8F-JJ-yDV">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bhR-tI-owX">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="sCC-wY-Abl">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wer-ja-W3q">
-                                                        <rect key="frame" x="176" y="504" width="23" height="25"/>
+                                                        <rect key="frame" x="195.66666666666666" y="543" width="23" height="25"/>
                                                         <state key="normal" image="Play"/>
                                                         <connections>
                                                             <action selector="playPause:" destination="9g2-2Z-FUe" eventType="touchUpInside" id="hQN-Jr-7hu"/>
                                                         </connections>
                                                     </button>
                                                     <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bzI-qL-pwk">
-                                                        <rect key="frame" x="19" y="507.5" width="23" height="18"/>
+                                                        <rect key="frame" x="19" y="546.66666666666663" width="23" height="18"/>
                                                         <state key="normal" image="Subtitles"/>
                                                         <connections>
                                                             <action selector="chooseSubtitle:" destination="9g2-2Z-FUe" eventType="touchUpInside" id="hjv-re-F8d"/>
                                                         </connections>
                                                     </button>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tgk-yf-Lhx">
-                                                        <rect key="frame" x="165.5" y="423" width="44" height="21"/>
+                                                        <rect key="frame" x="185" y="462" width="44" height="21"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="21" id="uhJ-ml-dIF"/>
                                                         </constraints>
@@ -1433,19 +1419,19 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="--:--" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OPV-HL-q7d">
-                                                        <rect key="frame" x="12" y="391" width="27" height="15"/>
+                                                        <rect key="frame" x="12" y="430" width="27" height="15"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="--:--" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iOU-Ub-Kzg">
-                                                        <rect key="frame" x="336" y="391" width="27" height="15"/>
+                                                        <rect key="frame" x="375" y="430" width="27" height="15"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="dqp-3E-NWP" customClass="ProgressSlider" customModule="PopcornTime" customModuleProvider="target">
-                                                        <rect key="frame" x="-2" y="360" width="379" height="31"/>
+                                                        <rect key="frame" x="-2" y="399" width="418" height="31"/>
                                                         <color key="minimumTrackTintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <color key="maximumTrackTintColor" red="1" green="1" blue="1" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <connections>
@@ -1455,7 +1441,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                         </connections>
                                                     </slider>
                                                     <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="0.0" maxValue="1" minimumValueImage="Volume Minimum" maximumValueImage="Volume Maximum" translatesAutoresizingMaskIntoConstraints="NO" id="Gng-sI-cdS">
-                                                        <rect key="frame" x="8" y="629" width="359" height="31"/>
+                                                        <rect key="frame" x="8" y="858" width="398" height="31"/>
                                                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <color key="minimumTrackTintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <color key="maximumTrackTintColor" red="1" green="1" blue="1" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1464,7 +1450,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                         </connections>
                                                     </slider>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cNf-Hh-jqc">
-                                                        <rect key="frame" x="93" y="502.5" width="28" height="28"/>
+                                                        <rect key="frame" x="112.66666666666667" y="541.66666666666663" width="28.000000000000014" height="28"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="28" id="nB5-hS-W5q"/>
                                                             <constraint firstAttribute="width" constant="28" id="tFA-Jc-ZE0"/>
@@ -1477,7 +1463,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="27u-Zm-lOe">
-                                                        <rect key="frame" x="254" y="502.5" width="28" height="28"/>
+                                                        <rect key="frame" x="273.66666666666669" y="541.66666666666663" width="28" height="28"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="28" id="98q-vI-fDg"/>
                                                             <constraint firstAttribute="width" constant="28" id="lu9-W6-myo"/>
@@ -1490,11 +1476,11 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KOj-4L-9mN">
-                                                        <rect key="frame" x="10" y="634.5" width="13" height="19"/>
+                                                        <rect key="frame" x="10" y="863.66666666666663" width="13" height="19"/>
                                                         <state key="normal" image="Volume Minimum"/>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Buq-BN-n87">
-                                                        <rect key="frame" x="332" y="630.5" width="33" height="27"/>
+                                                        <rect key="frame" x="371" y="859.66666666666663" width="33" height="27"/>
                                                         <state key="normal" image="Volume Maximum"/>
                                                     </button>
                                                 </subviews>
@@ -1524,7 +1510,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                             </vibrancyEffect>
                                         </visualEffectView>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="5" verticalHuggingPriority="5" horizontalCompressionResistancePriority="5" verticalCompressionResistancePriority="5" translatesAutoresizingMaskIntoConstraints="NO" id="UoZ-xq-0nq">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="375"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="414"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" priority="249" constant="432" id="XFV-32-w9P"/>
                                                 <constraint firstAttribute="width" secondItem="UoZ-xq-0nq" secondAttribute="height" multiplier="1:1" id="rEU-OK-HPb"/>
@@ -1574,16 +1560,17 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="zpx-Rj-7KQ" firstAttribute="width" secondItem="uYT-27-WQP" secondAttribute="width" id="Bcg-qm-JxV"/>
-                            <constraint firstItem="VEc-Xt-eHf" firstAttribute="centerX" secondItem="uYT-27-WQP" secondAttribute="centerX" id="RbP-Sd-Hy3"/>
+                            <constraint firstItem="VEc-Xt-eHf" firstAttribute="centerX" secondItem="DhU-j3-OlE" secondAttribute="centerX" id="RbP-Sd-Hy3"/>
                             <constraint firstItem="zpx-Rj-7KQ" firstAttribute="height" secondItem="uYT-27-WQP" secondAttribute="height" id="Sxs-jP-d3j"/>
                             <constraint firstItem="zpx-Rj-7KQ" firstAttribute="centerY" secondItem="uYT-27-WQP" secondAttribute="centerY" id="YgY-4f-xfw"/>
-                            <constraint firstItem="zpx-Rj-7KQ" firstAttribute="centerX" secondItem="uYT-27-WQP" secondAttribute="centerX" id="d2f-jU-rOB"/>
+                            <constraint firstItem="zpx-Rj-7KQ" firstAttribute="centerX" secondItem="DhU-j3-OlE" secondAttribute="centerX" id="d2f-jU-rOB"/>
                             <constraint firstItem="VEc-Xt-eHf" firstAttribute="width" secondItem="uYT-27-WQP" secondAttribute="width" id="ipX-iD-hkY"/>
                             <constraint firstItem="h7E-z9-GGj" firstAttribute="top" secondItem="uYT-27-WQP" secondAttribute="top" constant="25" id="kMx-hO-ESw"/>
                             <constraint firstItem="VEc-Xt-eHf" firstAttribute="centerY" secondItem="uYT-27-WQP" secondAttribute="centerY" id="mJ5-Wq-l5d"/>
                             <constraint firstItem="VEc-Xt-eHf" firstAttribute="height" secondItem="uYT-27-WQP" secondAttribute="height" id="qPD-Ei-ws7"/>
-                            <constraint firstItem="h7E-z9-GGj" firstAttribute="leading" secondItem="uYT-27-WQP" secondAttribute="leading" constant="10" id="xXR-Gd-YpC"/>
+                            <constraint firstItem="h7E-z9-GGj" firstAttribute="leading" secondItem="DhU-j3-OlE" secondAttribute="leading" constant="10" id="xXR-Gd-YpC"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="DhU-j3-OlE"/>
                     </view>
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
                     <connections>
@@ -1618,33 +1605,33 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
             <objects>
                 <tableViewController storyboardIdentifier="GoogleCastTableViewController" definesPresentationContext="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Rxu-HI-Dot" customClass="GoogleCastTableViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="lZe-Md-2A7">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="airPlayCell" textLabel="nef-aD-TPj" detailTextLabel="7fF-sK-M8v" imageView="y06-e4-tQC" style="IBUITableViewCellStyleSubtitle" id="o8j-uJ-s1u" customClass="AirPlayTableViewCell" customModule="PopcornTime" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="55.333332061767578" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="o8j-uJ-s1u" id="U98-Yr-xmP">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="More Devices" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nef-aD-TPj">
-                                            <rect key="frame" x="55" y="5" width="104.5" height="20.5"/>
+                                            <rect key="frame" x="59.000000000000007" y="5" width="104.66666666666667" height="20.333333333333332"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="AirPlay &amp; Bluetooth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7fF-sK-M8v">
-                                            <rect key="frame" x="55" y="25.5" width="109.5" height="14.5"/>
+                                            <rect key="frame" x="58.999999999999993" y="25.333333333333332" width="109.33333333333333" height="14.333333333333334"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" image="AirPlay" id="y06-e4-tQC">
-                                            <rect key="frame" x="16" y="13" width="24" height="17"/>
+                                            <rect key="frame" x="20" y="13.333333333333336" width="24" height="17"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <color key="tintColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                         </imageView>
@@ -1652,21 +1639,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="cell" textLabel="06M-0M-LNH" imageView="aYC-7i-YTA" style="IBUITableViewCellStyleDefault" id="R3q-0X-MyU">
-                                <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="99.333332061767578" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="R3q-0X-MyU" id="RdT-yo-5M3">
-                                    <rect key="frame" x="0.0" y="0.0" width="335" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="370" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="06M-0M-LNH">
-                                            <rect key="frame" x="61" y="0.0" width="274" height="43.5"/>
+                                            <rect key="frame" x="65" y="0.0" width="297" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" image="CastOff" id="aYC-7i-YTA">
-                                            <rect key="frame" x="16" y="6" width="30" height="30"/>
+                                            <rect key="frame" x="20" y="7" width="30" height="30"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <color key="tintColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                         </imageView>
@@ -1698,25 +1685,25 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
             <objects>
                 <tableViewController definesPresentationContext="YES" id="vbu-gi-gcV" customClass="OptionsTableViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="qQT-yY-2p8">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="delayCell" id="brJ-la-ayX" customClass="StepperTableViewCell" customModule="PopcornTime" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="55.333332061767578" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="brJ-la-ayX" id="i7t-hM-KGC">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" minimumValue="-60" maximumValue="60" translatesAutoresizingMaskIntoConstraints="NO" id="GHs-Hr-zXt">
-                                            <rect key="frame" x="258" y="7.5" width="94" height="29"/>
+                                            <rect key="frame" x="293" y="6" width="94" height="32"/>
                                             <connections>
                                                 <action selector="stepperPressed:" destination="brJ-la-ayX" eventType="valueChanged" id="yMn-rV-EdO"/>
                                             </connections>
                                         </stepper>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2J1-Lq-c9Y">
-                                            <rect key="frame" x="23" y="11.5" width="42" height="21"/>
+                                            <rect key="frame" x="27" y="11.666666666666664" width="42" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -1736,14 +1723,14 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="detailButton" indentationWidth="10" reuseIdentifier="cell" textLabel="0fp-J9-VPJ" style="IBUITableViewCellStyleDefault" id="Qmn-3M-w9d">
-                                <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="99.333332061767578" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Qmn-3M-w9d" id="neN-ek-Afu">
-                                    <rect key="frame" x="0.0" y="0.0" width="327" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="370" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="0fp-J9-VPJ">
-                                            <rect key="frame" x="16" y="0.0" width="311" height="43.5"/>
+                                            <rect key="frame" x="20" y="0.0" width="342" height="44"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1780,26 +1767,26 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
             <objects>
                 <tableViewController id="PeD-Pt-LoM" customClass="ExtendedSubtitleTableViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="hZh-Oj-fXq">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="cell" textLabel="Rdo-vj-c8T" detailTextLabel="4Hn-3o-ooO" style="IBUITableViewCellStyleSubtitle" id="Nwf-9S-QOv">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="55.666667938232422"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Nwf-9S-QOv" id="IbP-Fi-NAx">
-                                    <rect key="frame" x="0.0" y="0.0" width="335" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="370" height="55.666667938232422"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Rdo-vj-c8T">
-                                            <rect key="frame" x="16" y="5" width="33.5" height="20.5"/>
+                                            <rect key="frame" x="20.000000000000004" y="8.9999999999999982" width="33.333333333333336" height="20.333333333333332"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4Hn-3o-ooO">
-                                            <rect key="frame" x="16" y="25.5" width="44" height="14.5"/>
+                                            <rect key="frame" x="19.999999999999996" y="31.333333333333332" width="43.666666666666664" height="14.333333333333334"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <nil key="textColor"/>
@@ -1823,22 +1810,18 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="xvZ-1m-D1q">
             <objects>
                 <viewController storyboardIdentifier="EpisodeDetailViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Tqz-Ft-gWH" customClass="EpisodeDetailViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="ENK-yp-Xiz"/>
-                        <viewControllerLayoutGuide type="bottom" id="yth-Rw-gJW"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="hKQ-5r-Pi4">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="339.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="339.33333333333331"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mx3-z8-9it">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="339.5"/>
+                                <rect key="frame" x="0.0" y="44" width="375" height="295.33333333333331"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="IWe-kB-TAO" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="600.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="600.66666666666663"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" image="Episode Placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="Gaq-5q-Kfy">
-                                                <rect key="frame" x="24" y="24" width="327" height="163.5"/>
+                                                <rect key="frame" x="24" y="24" width="327" height="163.66666666666666"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Gaq-5q-Kfy" secondAttribute="height" multiplier="16:8" id="eei-8h-Rcq"/>
                                                 </constraints>
@@ -1850,25 +1833,25 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                 </userDefinedRuntimeAttributes>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eDs-4j-P8k">
-                                                <rect key="frame" x="24" y="197.5" width="327" height="16"/>
+                                                <rect key="frame" x="24" y="197.66666666666666" width="327" height="16"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <color key="textColor" white="1" alpha="0.59724361800000003" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pMS-Sz-8C3">
-                                                <rect key="frame" x="24" y="217.5" width="327" height="48"/>
+                                                <rect key="frame" x="24" y="217.66666666666669" width="327" height="48"/>
                                                 <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="40"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eu6-iu-pli">
-                                                <rect key="frame" x="24" y="275.5" width="327" height="18"/>
+                                                <rect key="frame" x="24" y="275.66666666666669" width="327" height="18"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KJW-mN-dnu" customClass="UIExpandableTextView" customModule="PopcornTime" customModuleProvider="target">
-                                                <rect key="frame" x="19" y="293.5" width="337" height="249"/>
+                                                <rect key="frame" x="19" y="293.66666666666669" width="337" height="249.00000000000006"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" white="1" alpha="0.59724361800000003" colorSpace="calibratedWhite"/>
@@ -1884,7 +1867,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="06G-0s-lRC" customClass="CircularButton" customModule="PopcornTime" customModuleProvider="target">
-                                                <rect key="frame" x="316" y="550.5" width="35" height="35"/>
+                                                <rect key="frame" x="316" y="550.66666666666663" width="35" height="35"/>
                                                 <color key="tintColor" red="0.36862745099999999" green="0.40784313729999999" blue="0.90980392160000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" image="Play Small"/>
                                                 <connections>
@@ -1932,12 +1915,13 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         <color key="backgroundColor" red="0.10980392160000001" green="0.10980392160000001" blue="0.10980392160000001" alpha="1" colorSpace="calibratedRGB"/>
                         <gestureRecognizers/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="mx3-z8-9it" secondAttribute="trailing" id="S7y-9p-7BF"/>
+                            <constraint firstItem="Lmz-Lj-cke" firstAttribute="trailing" secondItem="mx3-z8-9it" secondAttribute="trailing" id="S7y-9p-7BF"/>
                             <constraint firstAttribute="bottomMargin" secondItem="mx3-z8-9it" secondAttribute="bottom" id="Sd7-SG-HDH"/>
-                            <constraint firstItem="mx3-z8-9it" firstAttribute="leading" secondItem="hKQ-5r-Pi4" secondAttribute="leading" id="e79-kd-MZf"/>
+                            <constraint firstItem="mx3-z8-9it" firstAttribute="leading" secondItem="Lmz-Lj-cke" secondAttribute="leading" id="e79-kd-MZf"/>
                             <constraint firstItem="mx3-z8-9it" firstAttribute="width" secondItem="hKQ-5r-Pi4" secondAttribute="width" id="sDJ-sF-NUq"/>
                             <constraint firstItem="mx3-z8-9it" firstAttribute="top" secondItem="hKQ-5r-Pi4" secondAttribute="topMargin" id="v9t-0a-wvV"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="Lmz-Lj-cke"/>
                         <connections>
                             <outletCollection property="gestureRecognizers" destination="SRS-56-BYJ" appends="YES" id="gH5-b4-tIb"/>
                         </connections>
@@ -1969,11 +1953,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="slP-VS-yXk">
             <objects>
                 <viewController storyboardIdentifier="DetailViewController" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="iGR-Da-fZh" customClass="DetailViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="8NL-Zw-YmJ"/>
-                        <viewControllerLayoutGuide type="bottom" id="Zhr-91-xjZ"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Zf1-Rg-yue">
+                    <view key="view" contentMode="scaleToFill" id="Zf1-Rg-yue">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="1649"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -1982,13 +1962,13 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsVerticalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" translatesAutoresizingMaskIntoConstraints="NO" id="v3a-91-rQb">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="1649"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="1561"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d0c-rp-WTj">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1516.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1516.6666666666667"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="vja-bu-gfJ">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="1516.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="1516.6666666666667"/>
                                                 <subviews>
                                                     <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4QL-L3-n4a">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="300"/>
@@ -2001,27 +1981,27 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                         <rect key="frame" x="0.0" y="300" width="375" height="390"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ryY-hT-m8d" userLabel="Separator View">
-                                                                <rect key="frame" x="40" y="15" width="295" height="0.5"/>
+                                                                <rect key="frame" x="40" y="15" width="295" height="0.66666666666666607"/>
                                                                 <color key="backgroundColor" white="1" alpha="0.5" colorSpace="calibratedWhite"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="0.5" id="G1M-kz-qGY"/>
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r0b-Fz-t7J">
-                                                                <rect key="frame" x="40" y="27.5" width="197" height="0.0"/>
+                                                                <rect key="frame" x="40" y="27.666666666666686" width="197" height="0.0"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="22"/>
                                                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HQv-wQ-JIu">
-                                                                <rect key="frame" x="237" y="12.5" width="98" height="30"/>
+                                                                <rect key="frame" x="237" y="12.666666666666686" width="98" height="30"/>
                                                                 <state key="normal" title="More Seasons"/>
                                                                 <connections>
                                                                     <action selector="changeSeason:" destination="iGR-Da-fZh" eventType="touchUpInside" id="GUe-o9-gLt"/>
                                                                 </connections>
                                                             </button>
                                                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IrN-Fw-gRT">
-                                                                <rect key="frame" x="0.0" y="35.5" width="375" height="339.5"/>
+                                                                <rect key="frame" x="0.0" y="35.666666666666686" width="375" height="339.33333333333331"/>
                                                                 <color key="backgroundColor" red="0.10980392160000001" green="0.10980392160000001" blue="0.10980392160000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <connections>
                                                                     <segue destination="g6i-7k-d0B" kind="embed" identifier="embedEpisodes" id="ggU-2i-gWo"/>
@@ -2052,14 +2032,14 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                         <rect key="frame" x="0.0" y="690" width="375" height="315"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gZx-73-18E" userLabel="Separator View">
-                                                                <rect key="frame" x="40" y="15" width="295" height="0.5"/>
+                                                                <rect key="frame" x="40" y="15" width="295" height="0.66666666666666607"/>
                                                                 <color key="backgroundColor" white="1" alpha="0.5" colorSpace="calibratedWhite"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" priority="998" constant="0.5" id="VM1-79-bLV"/>
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Related" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FjO-E4-LAk">
-                                                                <rect key="frame" x="40" y="27.5" width="335" height="26.5"/>
+                                                                <rect key="frame" x="40" y="27.666666666666629" width="335" height="26.333333333333329"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="22"/>
                                                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                                 <nil key="highlightedColor"/>
@@ -2093,13 +2073,13 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                         <rect key="frame" x="0.0" y="1005" width="375" height="304"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Cast &amp; Crew" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AiH-XM-5Pv">
-                                                                <rect key="frame" x="40" y="15" width="335" height="26.5"/>
+                                                                <rect key="frame" x="40" y="14.999999999999998" width="335" height="26.333333333333329"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="22"/>
                                                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nrZ-wl-O1l">
-                                                                <rect key="frame" x="0.0" y="49.5" width="375" height="254.5"/>
+                                                                <rect key="frame" x="0.0" y="49.333333333333243" width="375" height="254.66666666666663"/>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                                 <connections>
                                                                     <segue destination="PQb-9S-L62" kind="embed" identifier="embedPeople" id="vdG-GO-Y3V"/>
@@ -2120,20 +2100,20 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yvD-OB-8h1">
-                                                        <rect key="frame" x="0.0" y="1309" width="375" height="207.5"/>
+                                                        <rect key="frame" x="0.0" y="1309" width="375" height="207.66666666666674"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PMh-Qq-zTm" userLabel="Separator View">
-                                                                <rect key="frame" x="40" y="0.0" width="295" height="0.5"/>
+                                                                <rect key="frame" x="40" y="0.0" width="295" height="0.66666666666666663"/>
                                                                 <color key="backgroundColor" white="1" alpha="0.5" colorSpace="calibratedWhite"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="0.5" id="9cI-Uw-gfb"/>
                                                                 </constraints>
                                                             </view>
                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="top" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="jLd-yS-5NW">
-                                                                <rect key="frame" x="0.0" y="12.5" width="375" height="180"/>
+                                                                <rect key="frame" x="0.0" y="12.666666666666742" width="375" height="180"/>
                                                                 <subviews>
                                                                     <containerView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JaO-EM-Uas">
-                                                                        <rect key="frame" x="40" y="0.0" width="132.5" height="110"/>
+                                                                        <rect key="frame" x="40" y="0.0" width="132.66666666666666" height="110"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="110" id="27c-SX-bHo"/>
                                                                         </constraints>
@@ -2142,7 +2122,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                                         </connections>
                                                                     </containerView>
                                                                     <containerView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0jg-ql-O8a">
-                                                                        <rect key="frame" x="202.5" y="0.0" width="132.5" height="180"/>
+                                                                        <rect key="frame" x="202.66666666666663" y="0.0" width="132.33333333333337" height="180"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="180" id="NG4-ZI-Kvx"/>
                                                                         </constraints>
@@ -2194,7 +2174,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </connections>
                             </scrollView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4R2-A9-rNw" customClass="GradientView" customModule="PopcornTime" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="66"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="66"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="66" id="LSg-cA-Ewl"/>
@@ -2212,20 +2192,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         <color key="backgroundColor" white="0.15102305429999999" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="4R2-A9-rNw" firstAttribute="top" secondItem="Zf1-Rg-yue" secondAttribute="topMargin" id="23A-19-SSZ"/>
-                            <constraint firstItem="v3a-91-rQb" firstAttribute="leading" secondItem="Zf1-Rg-yue" secondAttribute="leading" id="2X3-VU-PeI"/>
-                            <constraint firstAttribute="trailing" secondItem="v3a-91-rQb" secondAttribute="trailing" id="6aL-YC-BIm"/>
+                            <constraint firstItem="v3a-91-rQb" firstAttribute="leading" secondItem="8gE-Tu-pS9" secondAttribute="leading" id="2X3-VU-PeI"/>
+                            <constraint firstItem="8gE-Tu-pS9" firstAttribute="trailing" secondItem="v3a-91-rQb" secondAttribute="trailing" id="6aL-YC-BIm"/>
                             <constraint firstAttribute="bottom" secondItem="v3a-91-rQb" secondAttribute="bottom" id="GJu-Eo-gtj"/>
                             <constraint firstItem="v3a-91-rQb" firstAttribute="top" secondItem="Zf1-Rg-yue" secondAttribute="topMargin" id="N5n-mK-JLq"/>
-                            <constraint firstAttribute="trailing" secondItem="4R2-A9-rNw" secondAttribute="trailing" id="oSD-kV-iDd"/>
-                            <constraint firstItem="4R2-A9-rNw" firstAttribute="leading" secondItem="Zf1-Rg-yue" secondAttribute="leading" id="or4-fp-z5n"/>
+                            <constraint firstItem="8gE-Tu-pS9" firstAttribute="trailing" secondItem="4R2-A9-rNw" secondAttribute="trailing" id="oSD-kV-iDd"/>
+                            <constraint firstItem="4R2-A9-rNw" firstAttribute="leading" secondItem="8gE-Tu-pS9" secondAttribute="leading" id="or4-fp-z5n"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="8gE-Tu-pS9"/>
                     </view>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="u9L-Eb-ppD">
                         <rightBarButtonItems>
                             <barButtonItem id="tLb-IA-Gbh">
                                 <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="sjC-SA-gKC">
-                                    <rect key="frame" x="332" y="11" width="27" height="22"/>
+                                    <rect key="frame" x="305" y="3" width="54" height="38"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <state key="normal" image="Watched Off"/>
                                     <connections>
@@ -2235,7 +2216,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             </barButtonItem>
                             <barButtonItem id="UDr-ic-psW">
                                 <button key="customView" opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="f91-av-hbJ">
-                                    <rect key="frame" x="299" y="9" width="25" height="26"/>
+                                    <rect key="frame" x="267" y="0.0" width="30" height="44"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <state key="normal" image="Watchlist Off"/>
                                     <connections>
@@ -2245,7 +2226,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             </barButtonItem>
                             <barButtonItem id="fTm-fF-PBM">
                                 <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="ZCn-3l-0jx" customClass="CastIconButton" customModule="PopcornTime" customModuleProvider="target">
-                                    <rect key="frame" x="261" y="7" width="30" height="30"/>
+                                    <rect key="frame" x="199" y="0.0" width="60" height="44"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <state key="normal" image="CastOff"/>
                                     <connections>
@@ -2307,33 +2288,30 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="ecV-gu-orc">
             <objects>
                 <viewController id="MYh-Wq-ORu" customClass="MoviesViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="b8O-Xt-jme"/>
-                        <viewControllerLayoutGuide type="bottom" id="Zh6-7m-8dC"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="dKM-q7-GcN">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4eY-Rs-ucl">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <connections>
                                     <segue destination="PQb-9S-L62" kind="embed" identifier="embed" id="jdi-Jx-gGa"/>
                                 </connections>
                             </containerView>
                             <searchBar contentMode="redraw" fixedFrame="YES" insetsLayoutMarginsFromSafeArea="NO" barStyle="black" text="" placeholder="Enter magnet link" translatesAutoresizingMaskIntoConstraints="NO" id="3fT-Zg-xpU">
-                                <rect key="frame" x="0.0" y="-56" width="375" height="56"/>
+                                <rect key="frame" x="0.0" y="-56" width="414" height="56"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="URL" keyboardAppearance="alert" returnKeyType="go" textContentType="url"/>
                             </searchBar>
                         </subviews>
                         <color key="backgroundColor" red="0.10980392160000001" green="0.10980392160000001" blue="0.10980392160000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="4eY-Rs-ucl" secondAttribute="trailing" id="69t-37-1Xi"/>
+                            <constraint firstItem="3DD-m9-R3F" firstAttribute="trailing" secondItem="4eY-Rs-ucl" secondAttribute="trailing" id="69t-37-1Xi"/>
                             <constraint firstAttribute="bottom" secondItem="4eY-Rs-ucl" secondAttribute="bottom" id="G7P-Ly-Lul"/>
                             <constraint firstItem="4eY-Rs-ucl" firstAttribute="top" secondItem="dKM-q7-GcN" secondAttribute="top" id="aev-Qq-64b"/>
-                            <constraint firstItem="4eY-Rs-ucl" firstAttribute="leading" secondItem="dKM-q7-GcN" secondAttribute="leading" id="u0J-23-Zhh"/>
+                            <constraint firstItem="4eY-Rs-ucl" firstAttribute="leading" secondItem="3DD-m9-R3F" secondAttribute="leading" id="u0J-23-Zhh"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="3DD-m9-R3F"/>
                     </view>
                     <toolbarItems/>
                     <navigationItem key="navigationItem" title="Movies" id="5mk-DD-5Sg">
@@ -2373,16 +2351,12 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="WN4-Oh-GSb">
             <objects>
                 <viewController id="M2t-Mx-T4n" customClass="PersonViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="mjv-s3-tJN"/>
-                        <viewControllerLayoutGuide type="bottom" id="P4k-0Y-WCX"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="q4e-CK-NuK">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="254.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="254.66666666666666"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cH6-vX-BEe">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="254.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="254.66666666666666"/>
                                 <connections>
                                     <segue destination="PQb-9S-L62" kind="embed" identifier="embed" id="0jz-5F-ARv"/>
                                 </connections>
@@ -2390,11 +2364,12 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         </subviews>
                         <color key="backgroundColor" red="0.10980392160000001" green="0.10980392160000001" blue="0.10980392160000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="cH6-vX-BEe" firstAttribute="leading" secondItem="q4e-CK-NuK" secondAttribute="leading" id="EJk-bq-mZv"/>
+                            <constraint firstItem="cH6-vX-BEe" firstAttribute="leading" secondItem="Qnp-f3-6ln" secondAttribute="leading" id="EJk-bq-mZv"/>
                             <constraint firstAttribute="bottom" secondItem="cH6-vX-BEe" secondAttribute="bottom" id="ZI8-LE-yMg"/>
-                            <constraint firstAttribute="trailing" secondItem="cH6-vX-BEe" secondAttribute="trailing" id="cTh-Nz-npH"/>
+                            <constraint firstItem="Qnp-f3-6ln" firstAttribute="trailing" secondItem="cH6-vX-BEe" secondAttribute="trailing" id="cTh-Nz-npH"/>
                             <constraint firstItem="cH6-vX-BEe" firstAttribute="top" secondItem="q4e-CK-NuK" secondAttribute="top" id="gxb-cL-GDY"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="Qnp-f3-6ln"/>
                     </view>
                     <navigationItem key="navigationItem" title="Person" id="JtY-YJ-CVk"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" barStyle="black" prompted="NO"/>
@@ -2407,22 +2382,18 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="F3i-UG-1ov">
             <objects>
                 <viewController storyboardIdentifier="CheckForUpdatesViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="V6E-EE-yNP" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="xSX-8A-puU"/>
-                        <viewControllerLayoutGuide type="bottom" id="ppv-ea-dqb"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="FGi-CZ-5Xq">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Checking for updates..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="mhz-ex-gbt">
-                                <rect key="frame" x="125.5" y="90" width="183" height="20"/>
+                                <rect key="frame" x="125.66666666666669" y="90" width="183" height="20"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="qEl-31-U5N">
-                                <rect key="frame" x="95.5" y="90" width="20" height="20"/>
+                                <rect key="frame" x="95.666666666666671" y="90" width="20" height="20"/>
                             </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -2430,9 +2401,10 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             <constraint firstItem="mhz-ex-gbt" firstAttribute="leading" secondItem="qEl-31-U5N" secondAttribute="trailing" constant="10" id="FKT-eg-Jsj"/>
                             <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="mhz-ex-gbt" secondAttribute="trailing" id="Jsj-1F-YHM"/>
                             <constraint firstItem="mhz-ex-gbt" firstAttribute="centerY" secondItem="FGi-CZ-5Xq" secondAttribute="centerY" id="Ma6-1k-NIs"/>
-                            <constraint firstItem="mhz-ex-gbt" firstAttribute="centerX" secondItem="FGi-CZ-5Xq" secondAttribute="centerX" constant="10" id="fkb-fk-Ich"/>
+                            <constraint firstItem="mhz-ex-gbt" firstAttribute="centerX" secondItem="qMp-cY-R81" secondAttribute="centerX" constant="10" id="fkb-fk-Ich"/>
                             <constraint firstItem="mhz-ex-gbt" firstAttribute="centerY" secondItem="qEl-31-U5N" secondAttribute="centerY" id="gSp-rq-48f"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="qMp-cY-R81"/>
                     </view>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="414" height="200"/>
@@ -2445,22 +2417,18 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="QqZ-Yz-E76">
             <objects>
                 <viewController id="kRO-WR-uwJ" customClass="ItemViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="c9U-bo-aZ9"/>
-                        <viewControllerLayoutGuide type="bottom" id="HtV-0U-HOJ"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="rAK-UX-wfb">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="500"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D7a-aa-kCt">
-                                <rect key="frame" x="28" y="35" width="131" height="60"/>
+                                <rect key="frame" x="28" y="59" width="131" height="60"/>
                                 <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="50"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pPi-SQ-EWt" userLabel="Separator View">
-                                <rect key="frame" x="28" y="105" width="319" height="0.5"/>
+                                <rect key="frame" x="28" y="129" width="319" height="0.66666666666665719"/>
                                 <color key="backgroundColor" white="1" alpha="0.5" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" priority="999" constant="0.5" id="F0D-EX-LV8"/>
@@ -2468,7 +2436,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </constraints>
                             </view>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" image="Movie Placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="Gxj-Ca-zMU">
-                                <rect key="frame" x="28" y="125.5" width="159.5" height="239.5"/>
+                                <rect key="frame" x="28" y="149.66666666666663" width="159.66666666666666" height="239"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Gxj-Ca-zMU" secondAttribute="height" multiplier="1:1.5" id="VIV-q5-2jh"/>
                                     <constraint firstAttribute="width" priority="250" constant="136" id="pE5-Wi-OSI"/>
@@ -2481,25 +2449,25 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </userDefinedRuntimeAttributes>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I5a-CB-axO">
-                                <rect key="frame" x="207.5" y="130.5" width="42" height="20.5"/>
+                                <rect key="frame" x="207.66666666666666" y="154.66666666666666" width="41.666666666666657" height="20.333333333333343"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wq7-gM-WWf">
-                                <rect key="frame" x="207.5" y="159" width="42" height="20.5"/>
+                                <rect key="frame" x="207.66666666666666" y="183" width="41.666666666666657" height="20.333333333333343"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S2N-VK-bZ6">
-                                <rect key="frame" x="207.5" y="187.5" width="42" height="20.5"/>
+                                <rect key="frame" x="207.66666666666666" y="211.33333333333334" width="41.666666666666657" height="20.333333333333343"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yoG-Ac-iZY" customClass="FloatRatingView" customModule="FloatRatingView">
-                                <rect key="frame" x="207.5" y="216" width="120" height="20"/>
+                                <rect key="frame" x="207.66666666666663" y="239.66666666666666" width="120" height="19.999999999999972"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
@@ -2525,7 +2493,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="750" scrollEnabled="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="68M-4s-36K" customClass="UIExpandableTextView" customModule="PopcornTime" customModuleProvider="target">
-                                <rect key="frame" x="23" y="380" width="324" height="52"/>
+                                <rect key="frame" x="23" y="403.66666666666669" width="324" height="28.333333333333314"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -2533,7 +2501,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="g7G-QE-LfC">
-                                <rect key="frame" x="28" y="443.5" width="148" height="28"/>
+                                <rect key="frame" x="28" y="443.66666666666669" width="148" height="28"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jfc-cE-IJ4" customClass="BorderButton" customModule="PopcornTime" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="55" height="28"/>
@@ -2568,16 +2536,16 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         </subviews>
                         <color key="backgroundColor" red="0.10980392160000001" green="0.10980392160000001" blue="0.10980392160000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="pPi-SQ-EWt" secondAttribute="trailing" constant="28" id="1bJ-Fp-FEB"/>
+                            <constraint firstItem="DsU-aA-Llh" firstAttribute="trailing" secondItem="pPi-SQ-EWt" secondAttribute="trailing" constant="28" id="1bJ-Fp-FEB"/>
                             <constraint firstItem="Gxj-Ca-zMU" firstAttribute="leading" secondItem="D7a-aa-kCt" secondAttribute="leading" id="28I-85-gvR"/>
                             <constraint firstItem="D7a-aa-kCt" firstAttribute="top" secondItem="rAK-UX-wfb" secondAttribute="topMargin" constant="15" id="3Kv-lU-T4t"/>
                             <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="4ii-WE-PsJ" secondAttribute="bottom" constant="25" id="7mh-n6-n8v"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="yoG-Ac-iZY" secondAttribute="trailing" priority="250" constant="40" id="9VY-1K-ihJ"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="D7a-aa-kCt" secondAttribute="trailing" constant="40" id="9ms-0g-6PC"/>
+                            <constraint firstItem="DsU-aA-Llh" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="yoG-Ac-iZY" secondAttribute="trailing" priority="250" constant="40" id="9VY-1K-ihJ"/>
+                            <constraint firstItem="DsU-aA-Llh" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="D7a-aa-kCt" secondAttribute="trailing" constant="40" id="9ms-0g-6PC"/>
                             <constraint firstItem="4ii-WE-PsJ" firstAttribute="top" secondItem="68M-4s-36K" secondAttribute="bottom" constant="8" symbolic="YES" id="9wb-y8-yr8"/>
                             <constraint firstItem="Gxj-Ca-zMU" firstAttribute="top" secondItem="pPi-SQ-EWt" secondAttribute="bottom" priority="999" constant="20" id="AaC-B7-xoM"/>
-                            <constraint firstItem="Gxj-Ca-zMU" firstAttribute="trailing" secondItem="rAK-UX-wfb" secondAttribute="centerX" priority="999" id="BYn-QJ-vj4"/>
-                            <constraint firstItem="D7a-aa-kCt" firstAttribute="leading" secondItem="rAK-UX-wfb" secondAttribute="leading" priority="999" constant="28" id="BnT-FJ-4ji"/>
+                            <constraint firstItem="Gxj-Ca-zMU" firstAttribute="trailing" secondItem="DsU-aA-Llh" secondAttribute="centerX" priority="999" id="BYn-QJ-vj4"/>
+                            <constraint firstItem="D7a-aa-kCt" firstAttribute="leading" secondItem="DsU-aA-Llh" secondAttribute="leading" priority="999" constant="28" id="BnT-FJ-4ji"/>
                             <constraint firstItem="S2N-VK-bZ6" firstAttribute="top" secondItem="wq7-gM-WWf" secondAttribute="bottom" priority="999" constant="8" symbolic="YES" id="D41-Cb-hkf"/>
                             <constraint firstItem="68M-4s-36K" firstAttribute="leading" secondItem="I5a-CB-axO" secondAttribute="leading" priority="250" constant="-5" id="EFz-VB-HM8"/>
                             <constraint firstItem="68M-4s-36K" firstAttribute="leading" secondItem="Gxj-Ca-zMU" secondAttribute="leading" priority="999" constant="-5" id="GFB-dr-lhb"/>
@@ -2592,15 +2560,15 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             <constraint firstItem="68M-4s-36K" firstAttribute="top" secondItem="Gxj-Ca-zMU" secondAttribute="bottom" priority="999" constant="15" id="Tzc-Tu-YlA"/>
                             <constraint firstItem="yoG-Ac-iZY" firstAttribute="leading" secondItem="S2N-VK-bZ6" secondAttribute="leading" priority="999" id="UcO-Dd-bNu"/>
                             <constraint firstItem="I5a-CB-axO" firstAttribute="leading" secondItem="Gxj-Ca-zMU" secondAttribute="trailing" constant="20" id="Ypc-5Q-2y8"/>
-                            <constraint firstItem="D7a-aa-kCt" firstAttribute="leading" secondItem="rAK-UX-wfb" secondAttribute="leading" priority="250" constant="40" id="ZcN-es-PPx"/>
+                            <constraint firstItem="D7a-aa-kCt" firstAttribute="leading" secondItem="DsU-aA-Llh" secondAttribute="leading" priority="250" constant="40" id="ZcN-es-PPx"/>
                             <constraint firstItem="wq7-gM-WWf" firstAttribute="top" secondItem="I5a-CB-axO" secondAttribute="bottom" priority="999" constant="8" symbolic="YES" id="anr-qg-rrl"/>
                             <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="Gxj-Ca-zMU" secondAttribute="bottom" priority="250" constant="25" id="c41-5E-Qw6"/>
-                            <constraint firstAttribute="trailing" secondItem="68M-4s-36K" secondAttribute="trailing" priority="999" constant="28" id="c8P-D5-OJc"/>
+                            <constraint firstItem="DsU-aA-Llh" firstAttribute="trailing" secondItem="68M-4s-36K" secondAttribute="trailing" priority="999" constant="28" id="c8P-D5-OJc"/>
                             <constraint firstItem="yoG-Ac-iZY" firstAttribute="leading" secondItem="S2N-VK-bZ6" secondAttribute="trailing" priority="250" constant="10" id="cmD-sP-TP2"/>
                             <constraint firstItem="wq7-gM-WWf" firstAttribute="leading" secondItem="I5a-CB-axO" secondAttribute="leading" priority="999" id="eFK-Fc-Yyb"/>
                             <constraint firstItem="S2N-VK-bZ6" firstAttribute="leading" secondItem="wq7-gM-WWf" secondAttribute="trailing" priority="250" constant="8" symbolic="YES" id="h8n-a0-vQJ"/>
-                            <constraint firstAttribute="trailing" secondItem="4ii-WE-PsJ" secondAttribute="trailing" constant="36" id="j5g-pG-RVe"/>
-                            <constraint firstAttribute="trailing" secondItem="68M-4s-36K" secondAttribute="trailing" priority="250" constant="40" id="jLr-Ep-9oS"/>
+                            <constraint firstItem="DsU-aA-Llh" firstAttribute="trailing" secondItem="4ii-WE-PsJ" secondAttribute="trailing" constant="36" id="j5g-pG-RVe"/>
+                            <constraint firstItem="DsU-aA-Llh" firstAttribute="trailing" secondItem="68M-4s-36K" secondAttribute="trailing" priority="250" constant="40" id="jLr-Ep-9oS"/>
                             <constraint firstItem="yoG-Ac-iZY" firstAttribute="top" secondItem="S2N-VK-bZ6" secondAttribute="bottom" priority="999" constant="8" symbolic="YES" id="klx-bz-RGg"/>
                             <constraint firstItem="wq7-gM-WWf" firstAttribute="top" secondItem="I5a-CB-axO" secondAttribute="top" priority="250" id="oKk-v7-RCL"/>
                             <constraint firstItem="S2N-VK-bZ6" firstAttribute="top" secondItem="wq7-gM-WWf" secondAttribute="top" priority="250" id="qGv-3b-uyb"/>
@@ -2608,6 +2576,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             <constraint firstItem="Gxj-Ca-zMU" firstAttribute="top" secondItem="D7a-aa-kCt" secondAttribute="bottom" priority="250" constant="15" id="xwk-hF-aIk"/>
                             <constraint firstItem="4ii-WE-PsJ" firstAttribute="centerY" secondItem="g7G-QE-LfC" secondAttribute="centerY" id="zp8-yW-R0b"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="DsU-aA-Llh"/>
                     </view>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="375" height="500"/>
@@ -2661,7 +2630,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
             <objects>
                 <collectionViewController id="g6i-7k-d0B" customClass="EpisodesCollectionViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" id="W9A-Qh-oNf">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="339.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="339.33333333333331"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.10980392160000001" green="0.10980392160000001" blue="0.10980392160000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="20" minimumInteritemSpacing="0.5" id="phM-z6-OWQ" customClass="SeparatorCollectionViewLayout" customModule="PopcornTime" customModuleProvider="target">
@@ -2679,7 +2648,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             </userDefinedRuntimeAttributes>
                         </collectionViewFlowLayout>
                         <cells>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" insetsLayoutMarginsFromSafeArea="NO" reuseIdentifier="cell" id="qa8-GZ-Vm1" customClass="EpisodeCollectionViewCell" customModule="PopcornTime" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" reuseIdentifier="cell" id="qa8-GZ-Vm1" customClass="EpisodeCollectionViewCell" customModule="PopcornTime" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="55"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -2687,14 +2656,14 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VZX-QC-Dxh">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="55"/>
                                             <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                         </view>
                                         <view contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Sbb-CL-YeZ" userLabel="Content View">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="55"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" image="Episode Placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="nc2-GD-wNs">
-                                                    <rect key="frame" x="8" y="8" width="319.5" height="179.5"/>
+                                                    <rect key="frame" x="8" y="8" width="69.333333333333329" height="39"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="nc2-GD-wNs" secondAttribute="height" multiplier="16:9" id="47J-wL-ccG"/>
                                                     </constraints>
@@ -2706,13 +2675,13 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                                     </userDefinedRuntimeAttributes>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uKh-Xl-6wC">
-                                                    <rect key="frame" x="339.5" y="79.5" width="35.5" height="20.5"/>
+                                                    <rect key="frame" x="89.333333333333329" y="9.0000000000000018" width="230.66666666666669" height="20.666666666666671"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EV3-M2-mbY">
-                                                    <rect key="frame" x="339.5" y="100" width="35.5" height="17"/>
+                                                    <rect key="frame" x="89.333333333333329" y="29.666666666666671" width="230.66666666666669" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" white="1" alpha="0.59724361800000003" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
@@ -2732,10 +2701,10 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                             </constraints>
                                         </view>
                                         <view contentMode="scaleToFill" horizontalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NcM-KK-VlL" userLabel="Accessory View">
-                                            <rect key="frame" x="375" y="0.0" width="0.0" height="0.0"/>
+                                            <rect key="frame" x="320" y="0.0" width="55" height="55"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aeK-e0-ISc">
-                                                    <rect key="frame" x="-13.5" y="-9.5" width="27" height="19"/>
+                                                    <rect key="frame" x="14" y="18" width="27" height="19"/>
                                                     <state key="normal" image="Watched Off"/>
                                                     <connections>
                                                         <action selector="toggleWatched" destination="qa8-GZ-Vm1" eventType="touchUpInside" id="O6Z-fa-faT"/>
@@ -2791,7 +2760,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
             <objects>
                 <collectionViewController id="bd3-Qn-q9Z" customClass="DescriptionCollectionViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" dataMode="prototypes" id="sOh-NB-hk2">
-                        <rect key="frame" x="0.0" y="0.0" width="132.5" height="110"/>
+                        <rect key="frame" x="0.0" y="0.0" width="132.66666666666666" height="110"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="0.15102305429999999" alpha="1" colorSpace="calibratedWhite"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="cpO-dI-caQ">
@@ -2802,11 +2771,11 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         </collectionViewFlowLayout>
                         <cells/>
                         <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="header" id="92f-zo-M9u">
-                            <rect key="frame" x="0.0" y="0.0" width="132.5" height="50"/>
+                            <rect key="frame" x="0.0" y="0.0" width="132.66666666666666" height="50"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YDg-9W-SRl">
-                                    <rect key="frame" x="39.5" y="13" width="54" height="24"/>
+                                    <rect key="frame" x="39.333333333333343" y="13" width="54" height="24"/>
                                     <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="20"/>
                                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <nil key="highlightedColor"/>
@@ -2832,7 +2801,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
             <objects>
                 <collectionViewController id="PQb-9S-L62" customClass="CollectionViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" delaysContentTouches="NO" dataMode="prototypes" prefetchingEnabled="NO" id="hRU-yH-dJG">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="254.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="254.66666666666666"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="15" minimumInteritemSpacing="30" id="qut-UB-4YD">
@@ -2842,7 +2811,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             <inset key="sectionInset" minX="15" minY="15" maxX="15" maxY="15"/>
                         </collectionViewFlowLayout>
                         <cells>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" reuseIdentifier="showCell" id="DFM-c1-K1Z" customClass="CoverCollectionViewCell" customModule="PopcornTime" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="showCell" id="DFM-c1-K1Z" customClass="CoverCollectionViewCell" customModule="PopcornTime" customModuleProvider="target">
                                 <rect key="frame" x="15" y="55" width="108" height="180"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -2896,7 +2865,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                     <segue destination="0ID-k2-iS4" kind="show" identifier="showShow" customClass="AutoPlayStoryboardSegue" customModule="PopcornTime" customModuleProvider="target" id="ILG-Tj-6E6"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" reuseIdentifier="movieCell" id="7iq-Qv-wgC" customClass="CoverCollectionViewCell" customModule="PopcornTime" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="movieCell" id="7iq-Qv-wgC" customClass="CoverCollectionViewCell" customModule="PopcornTime" customModuleProvider="target">
                                 <rect key="frame" x="252" y="55" width="108" height="180"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -2950,7 +2919,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                     <segue destination="0ID-k2-iS4" kind="show" identifier="showMovie" customClass="AutoPlayStoryboardSegue" customModule="PopcornTime" customModuleProvider="target" id="ikm-my-cK3"/>
                                 </connections>
                             </collectionViewCell>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" reuseIdentifier="personCell" id="PFe-jc-BLR" customClass="MonogramCollectionViewCell" customModule="PopcornTime" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="personCell" id="PFe-jc-BLR" customClass="MonogramCollectionViewCell" customModule="PopcornTime" customModuleProvider="target">
                                 <rect key="frame" x="15" y="250" width="108" height="180"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -3018,12 +2987,12 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                 </connections>
                             </collectionViewCell>
                         </cells>
-                        <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" reuseIdentifier="sectionHeader" id="tl4-ol-aPl">
+                        <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="sectionHeader" id="tl4-ol-aPl">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="40"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KtC-S6-Flo">
-                                    <rect key="frame" x="15" y="-13.5" width="59" height="27"/>
+                                    <rect key="frame" x="15" y="6.6666666666666679" width="59" height="27.000000000000004"/>
                                     <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="22"/>
                                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <nil key="highlightedColor"/>
@@ -3054,7 +3023,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                     <toolbarItems/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" barStyle="black" prompted="NO"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="FUv-Ei-Wqw">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -3072,7 +3041,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Ixx-5j-Wih" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="tnH-0K-LRK">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -3090,7 +3059,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="BcV-kc-8G4" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="4YB-l6-RFX">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -3109,7 +3078,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                     <toolbarItems/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" barStyle="black" prompted="NO"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="7oc-zC-872">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -3126,7 +3095,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
             <objects>
                 <tableViewController storyboardIdentifier="SettingsTableViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="eg2-4N-lv1" customClass="SettingsTableViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="cp4-3h-X4E">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.1176470588" green="0.1176470588" blue="0.1176470588" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="separatorColor" red="0.2274509804" green="0.2274509804" blue="0.2274509804" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3136,21 +3105,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             <tableViewSection headerTitle="Player" id="nkF-CT-1o9">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="dRe-gM-t3G" detailTextLabel="6mU-Z1-awE" style="IBUITableViewCellStyleValue1" id="cbQ-rc-dud">
-                                        <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.333332061767578" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cbQ-rc-dud" id="guO-Gy-j8d">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Stream on cellular network" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dRe-gM-t3G">
-                                                    <rect key="frame" x="15" y="12" width="204" height="20.5"/>
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="203.66666666666666" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="On" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6mU-Z1-awE">
-                                                    <rect key="frame" x="336.5" y="12" width="22.5" height="20.5"/>
+                                                    <rect key="frame" x="371.66666666666669" y="11.999999999999998" width="22.333333333333332" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
@@ -3162,21 +3131,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                         <color key="backgroundColor" red="0.1019607843" green="0.1019607843" blue="0.1019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="hxp-ii-Yl3" detailTextLabel="jMo-Mc-dcl" style="IBUITableViewCellStyleValue1" id="fzi-2f-O5B">
-                                        <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="99.333332061767578" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fzi-2f-O5B" id="sP8-Fk-U0n">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Clear cache upon exit" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hxp-ii-Yl3">
-                                                    <rect key="frame" x="15" y="12" width="165.5" height="20.5"/>
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="165.66666666666666" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Off" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jMo-Mc-dcl">
-                                                    <rect key="frame" x="334.5" y="12" width="24.5" height="20.5"/>
+                                                    <rect key="frame" x="369.66666666666669" y="11.999999999999998" width="24.333333333333332" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
@@ -3188,21 +3157,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                         <color key="backgroundColor" red="0.1019607843" green="0.1019607843" blue="0.1019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="nX0-XM-0D1" detailTextLabel="ZxP-1x-xc0" style="IBUITableViewCellStyleValue1" id="8ho-4M-cFO">
-                                        <rect key="frame" x="0.0" y="143.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="143.33333206176758" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="8ho-4M-cFO" id="X7C-ye-srM">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Auto select quality" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nX0-XM-0D1">
-                                                    <rect key="frame" x="15" y="12" width="141.5" height="20.5"/>
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="141.33333333333334" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Off" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ZxP-1x-xc0">
-                                                    <rect key="frame" x="334.5" y="12" width="24.5" height="20.5"/>
+                                                    <rect key="frame" x="369.66666666666669" y="11.999999999999998" width="24.333333333333332" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
@@ -3218,21 +3187,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             <tableViewSection headerTitle="Subtitles" id="G0K-DS-ErA">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="0.0" textLabel="IhV-p0-PbG" detailTextLabel="KTt-ho-PY4" style="IBUITableViewCellStyleValue1" id="dCw-LU-ZrZ">
-                                        <rect key="frame" x="0.0" y="243.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="243.33333206176758" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dCw-LU-ZrZ" id="pDz-Zu-idb">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="IhV-p0-PbG">
-                                                    <rect key="frame" x="15" y="12" width="76" height="20.5"/>
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="75.666666666666671" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" alpha="0.5" contentMode="left" text="Normal" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="KTt-ho-PY4">
-                                                    <rect key="frame" x="303.5" y="12" width="55.5" height="20.5"/>
+                                                    <rect key="frame" x="338.33333333333331" y="11.999999999999998" width="55.666666666666664" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3244,21 +3213,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                         <color key="backgroundColor" red="0.1019607843" green="0.1019607843" blue="0.1019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="0.0" textLabel="dbX-zT-QDj" detailTextLabel="3F3-c1-ZzI" style="IBUITableViewCellStyleValue1" id="Pgk-BJ-2Bh">
-                                        <rect key="frame" x="0.0" y="287.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="287.33333206176758" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Pgk-BJ-2Bh" id="K9m-VG-qef">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Size" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dbX-zT-QDj">
-                                                    <rect key="frame" x="15" y="12" width="32.5" height="20.5"/>
+                                                    <rect key="frame" x="20.000000000000004" y="11.999999999999998" width="32.333333333333336" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" alpha="0.5" contentMode="left" text="25" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3F3-c1-ZzI">
-                                                    <rect key="frame" x="338.5" y="12" width="20.5" height="20.5"/>
+                                                    <rect key="frame" x="373.66666666666669" y="11.999999999999998" width="20.333333333333332" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3270,21 +3239,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                         <color key="backgroundColor" red="0.1019607843" green="0.1019607843" blue="0.1019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="0.0" textLabel="bNa-8T-fEm" detailTextLabel="OvG-mg-4e9" style="IBUITableViewCellStyleValue1" id="kay-4L-fXv">
-                                        <rect key="frame" x="0.0" y="331.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="331.33333206176758" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="kay-4L-fXv" id="oZ7-94-DPl">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Color" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bNa-8T-fEm">
-                                                    <rect key="frame" x="15" y="12" width="41.5" height="20.5"/>
+                                                    <rect key="frame" x="20.000000000000004" y="11.999999999999998" width="41.333333333333336" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" alpha="0.5" contentMode="left" text="White" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="OvG-mg-4e9">
-                                                    <rect key="frame" x="314" y="12" width="45" height="20.5"/>
+                                                    <rect key="frame" x="349.33333333333331" y="11.999999999999998" width="44.666666666666664" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3296,21 +3265,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                         <color key="backgroundColor" red="0.1019607843" green="0.1019607843" blue="0.1019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="0.0" textLabel="Y47-ht-KPO" detailTextLabel="eaA-e8-haC" style="IBUITableViewCellStyleValue1" id="aYN-Yo-pK5">
-                                        <rect key="frame" x="0.0" y="375.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="375.33333206176758" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="aYN-Yo-pK5" id="tHY-dM-rZd">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Font" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Y47-ht-KPO">
-                                                    <rect key="frame" x="15" y="12" width="34.5" height="20.5"/>
+                                                    <rect key="frame" x="20.000000000000004" y="11.999999999999998" width="34.333333333333336" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" alpha="0.5" contentMode="left" text="System" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="eaA-e8-haC">
-                                                    <rect key="frame" x="302" y="12" width="57" height="20.5"/>
+                                                    <rect key="frame" x="337" y="11.999999999999998" width="57" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3322,21 +3291,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                         <color key="backgroundColor" red="0.1019607843" green="0.1019607843" blue="0.1019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="0.0" textLabel="Hn7-3m-7mw" detailTextLabel="xXp-f5-HDR" style="IBUITableViewCellStyleValue1" id="enf-3Q-nGs">
-                                        <rect key="frame" x="0.0" y="419.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="419.33333206176758" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="enf-3Q-nGs" id="NBI-yk-Zz0">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Style" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Hn7-3m-7mw">
-                                                    <rect key="frame" x="15" y="12" width="38.5" height="20.5"/>
+                                                    <rect key="frame" x="20.000000000000004" y="11.999999999999998" width="38.333333333333336" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" alpha="0.5" contentMode="left" text="Normal" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="xXp-f5-HDR">
-                                                    <rect key="frame" x="303.5" y="12" width="55.5" height="20.5"/>
+                                                    <rect key="frame" x="338.33333333333331" y="11.999999999999998" width="55.666666666666664" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3348,21 +3317,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                         <color key="backgroundColor" red="0.1019607843" green="0.1019607843" blue="0.1019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="0.0" textLabel="tt3-ub-w91" detailTextLabel="FVI-gk-M7x" style="IBUITableViewCellStyleValue1" id="j9S-BI-ULK">
-                                        <rect key="frame" x="0.0" y="463.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="463.33333206176758" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="j9S-BI-ULK" id="Zqn-tF-sbZ">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Encoding" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="tt3-ub-w91">
-                                                    <rect key="frame" x="15" y="12" width="71.5" height="20.5"/>
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="71.666666666666671" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" alpha="0.5" contentMode="left" text="Windows-1252" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FVI-gk-M7x">
-                                                    <rect key="frame" x="244" y="12" width="115" height="20.5"/>
+                                                    <rect key="frame" x="279" y="11.999999999999998" width="115" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3378,21 +3347,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             <tableViewSection headerTitle="Services" id="2f8-BX-9jE">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="0.0" textLabel="R4t-Mj-Mny" detailTextLabel="wBP-QA-czk" style="IBUITableViewCellStyleValue1" id="w0D-Au-KQD">
-                                        <rect key="frame" x="0.0" y="563.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="563.33333206176758" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="w0D-Au-KQD" id="mcY-YE-2Zd">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Trakt" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="R4t-Mj-Mny">
-                                                    <rect key="frame" x="15" y="12" width="39" height="20.5"/>
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="39" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Sign In" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wBP-QA-czk">
-                                                    <rect key="frame" x="307" y="12" width="52" height="20.5"/>
+                                                    <rect key="frame" x="342" y="11.999999999999998" width="52" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
@@ -3408,14 +3377,14 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                             <tableViewSection headerTitle="Info" id="viZ-pA-ncL">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="0.0" textLabel="TJk-sQ-cdo" style="IBUITableViewCellStyleDefault" id="uCY-Hf-qQj">
-                                        <rect key="frame" x="0.0" y="663.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="663.33333206176758" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uCY-Hf-qQj" id="yJa-mc-NIu">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Clear all cache" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="TJk-sQ-cdo">
-                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <rect key="frame" x="20" y="0.0" width="374" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3427,21 +3396,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                         <color key="backgroundColor" red="0.1019607843" green="0.1019607843" blue="0.1019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="0.0" textLabel="hRo-AR-mJc" detailTextLabel="Zl6-g9-nMa" style="IBUITableViewCellStyleValue1" id="OzN-r5-NHV">
-                                        <rect key="frame" x="0.0" y="707.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="707.33333206176758" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="OzN-r5-NHV" id="AJk-vQ-TkC">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Check for updates" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hRo-AR-mJc">
-                                                    <rect key="frame" x="15" y="12" width="141" height="20.5"/>
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="141" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Never" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zl6-g9-nMa">
-                                                    <rect key="frame" x="314.5" y="12" width="45.5" height="20.5"/>
+                                                    <rect key="frame" x="348.66666666666669" y="11.999999999999998" width="45.333333333333336" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3453,21 +3422,21 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                                         <color key="backgroundColor" red="0.1019607843" green="0.1019607843" blue="0.1019607843" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="0.0" textLabel="Jut-a4-TVs" detailTextLabel="VFZ-aP-RU0" style="IBUITableViewCellStyleValue1" id="BtB-me-Oew">
-                                        <rect key="frame" x="0.0" y="751.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="751.33333206176758" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="BtB-me-Oew" id="sIq-Y1-FUp">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Jut-a4-TVs">
-                                                    <rect key="frame" x="15" y="12" width="54" height="19.5"/>
+                                                    <rect key="frame" x="20" y="12.999999999999998" width="54" height="19.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="0.0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="VFZ-aP-RU0">
-                                                    <rect key="frame" x="337" y="12" width="23" height="19.5"/>
+                                                    <rect key="frame" x="371" y="12.999999999999998" width="23" height="19.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -3505,7 +3474,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                     <tabBarItem key="tabBarItem" systemItem="search" id="5w9-0i-qNO"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="wRp-mt-m8V">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -3521,26 +3490,22 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="bIs-fu-Cw7">
             <objects>
                 <viewController storyboardIdentifier="SearchViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="y1e-J1-dTa" customClass="SearchViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="nka-kj-idW"/>
-                        <viewControllerLayoutGuide type="bottom" id="YpP-NO-Zrw"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="k5h-gR-wBm">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GtX-6m-GsZ">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <connections>
                                     <segue destination="PQb-9S-L62" kind="embed" identifier="embed" id="LPG-FZ-KwN"/>
                                 </connections>
                             </containerView>
                             <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" barStyle="black" translatesAutoresizingMaskIntoConstraints="NO" id="Big-rd-wfu">
-                                <rect key="frame" x="0.0" y="64" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="44"/>
                                 <items>
                                     <barButtonItem id="xvh-WI-bZQ">
-                                        <segmentedControl key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="rnl-zo-p9N">
-                                            <rect key="frame" x="16" y="7" width="343" height="30"/>
+                                        <segmentedControl key="customView" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="rnl-zo-p9N">
+                                            <rect key="frame" x="20" y="6" width="374" height="32"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <segments>
                                                 <segment title="Movies"/>
@@ -3562,12 +3527,13 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         <constraints>
                             <constraint firstItem="GtX-6m-GsZ" firstAttribute="top" secondItem="k5h-gR-wBm" secondAttribute="top" id="90L-rK-4mF"/>
                             <constraint firstAttribute="bottom" secondItem="GtX-6m-GsZ" secondAttribute="bottom" id="IDP-Na-gfU"/>
-                            <constraint firstAttribute="trailing" secondItem="GtX-6m-GsZ" secondAttribute="trailing" id="NnL-f8-dUx"/>
-                            <constraint firstAttribute="trailing" secondItem="Big-rd-wfu" secondAttribute="trailing" id="i2b-f4-YUe"/>
-                            <constraint firstItem="Big-rd-wfu" firstAttribute="top" secondItem="nka-kj-idW" secondAttribute="bottom" id="mhW-wi-ZoD"/>
-                            <constraint firstItem="GtX-6m-GsZ" firstAttribute="leading" secondItem="k5h-gR-wBm" secondAttribute="leading" id="rrz-rO-Qn2"/>
-                            <constraint firstItem="Big-rd-wfu" firstAttribute="leading" secondItem="k5h-gR-wBm" secondAttribute="leading" id="ujU-NS-CQi"/>
+                            <constraint firstItem="0IX-3h-t3A" firstAttribute="trailing" secondItem="GtX-6m-GsZ" secondAttribute="trailing" id="NnL-f8-dUx"/>
+                            <constraint firstItem="0IX-3h-t3A" firstAttribute="trailing" secondItem="Big-rd-wfu" secondAttribute="trailing" id="i2b-f4-YUe"/>
+                            <constraint firstItem="Big-rd-wfu" firstAttribute="top" secondItem="0IX-3h-t3A" secondAttribute="top" id="mhW-wi-ZoD"/>
+                            <constraint firstItem="GtX-6m-GsZ" firstAttribute="leading" secondItem="0IX-3h-t3A" secondAttribute="leading" id="rrz-rO-Qn2"/>
+                            <constraint firstItem="Big-rd-wfu" firstAttribute="leading" secondItem="0IX-3h-t3A" secondAttribute="leading" id="ujU-NS-CQi"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="0IX-3h-t3A"/>
                     </view>
                     <navigationItem key="navigationItem" id="Pec-xI-Km0">
                         <barButtonItem key="leftBarButtonItem" image="Settings Off" id="Pok-5y-fjY">
@@ -3590,6 +3556,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                     <rect key="frame" x="0.0" y="0.0" width="364" height="44"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    <viewLayoutGuide key="safeArea" id="nIh-70-DzQ"/>
                     <color key="barTintColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <textInputTraits key="textInputTraits" keyboardAppearance="alert" returnKeyType="search"/>
                     <connections>
@@ -3603,33 +3570,30 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="hcl-Mj-RWa">
             <objects>
                 <viewController id="kbi-CQ-znz" customClass="ShowsViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="7WS-BA-piG"/>
-                        <viewControllerLayoutGuide type="bottom" id="HcN-hH-9eE"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="fTD-BN-RBL">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LCt-HT-0Ar">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <connections>
                                     <segue destination="PQb-9S-L62" kind="embed" identifier="embed" id="K6U-5X-Quc"/>
                                 </connections>
                             </containerView>
                             <searchBar contentMode="redraw" fixedFrame="YES" insetsLayoutMarginsFromSafeArea="NO" barStyle="black" text="" placeholder="Enter magnet link" translatesAutoresizingMaskIntoConstraints="NO" id="CSv-BD-QT9">
-                                <rect key="frame" x="0.0" y="-56" width="375" height="56"/>
+                                <rect key="frame" x="0.0" y="-56" width="414" height="56"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="URL" keyboardAppearance="alert" returnKeyType="go" textContentType="url"/>
                             </searchBar>
                         </subviews>
                         <color key="backgroundColor" red="0.10980392160000001" green="0.10980392160000001" blue="0.10980392160000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="LCt-HT-0Ar" firstAttribute="leading" secondItem="fTD-BN-RBL" secondAttribute="leading" id="8YY-j8-168"/>
+                            <constraint firstItem="LCt-HT-0Ar" firstAttribute="leading" secondItem="3ZV-3S-U94" secondAttribute="leading" id="8YY-j8-168"/>
                             <constraint firstAttribute="bottom" secondItem="LCt-HT-0Ar" secondAttribute="bottom" id="99t-x5-dX0"/>
                             <constraint firstItem="LCt-HT-0Ar" firstAttribute="top" secondItem="fTD-BN-RBL" secondAttribute="top" id="Z7o-sJ-Ge7"/>
-                            <constraint firstAttribute="trailing" secondItem="LCt-HT-0Ar" secondAttribute="trailing" id="zzL-Ng-CmW"/>
+                            <constraint firstItem="3ZV-3S-U94" firstAttribute="trailing" secondItem="LCt-HT-0Ar" secondAttribute="trailing" id="zzL-Ng-CmW"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="3ZV-3S-U94"/>
                     </view>
                     <navigationItem key="navigationItem" title="Shows" id="ICQ-n2-fMx">
                         <barButtonItem key="leftBarButtonItem" image="Settings Off" id="tlh-3J-gQI">
@@ -3667,16 +3631,12 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="GxD-b4-iqY">
             <objects>
                 <viewController id="OvO-2i-5bX" customClass="WatchlistViewController" customModule="PopcornTime" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="cpM-4g-rZ1"/>
-                        <viewControllerLayoutGuide type="bottom" id="3pS-hw-ezE"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="YrJ-Dj-lSo">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cI3-ta-hDD">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <connections>
                                     <segue destination="PQb-9S-L62" kind="embed" identifier="embed" id="UvW-7j-iLo"/>
                                 </connections>
@@ -3684,11 +3644,12 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
                         </subviews>
                         <color key="backgroundColor" red="0.10980392160000001" green="0.10980392160000001" blue="0.10980392160000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="cI3-ta-hDD" firstAttribute="leading" secondItem="YrJ-Dj-lSo" secondAttribute="leading" id="0dU-8T-Gzy"/>
+                            <constraint firstItem="cI3-ta-hDD" firstAttribute="leading" secondItem="R7s-0B-EOi" secondAttribute="leading" id="0dU-8T-Gzy"/>
                             <constraint firstAttribute="bottom" secondItem="cI3-ta-hDD" secondAttribute="bottom" id="NUl-LK-lfm"/>
-                            <constraint firstAttribute="trailing" secondItem="cI3-ta-hDD" secondAttribute="trailing" id="Z1P-H6-Y2i"/>
+                            <constraint firstItem="R7s-0B-EOi" firstAttribute="trailing" secondItem="cI3-ta-hDD" secondAttribute="trailing" id="Z1P-H6-Y2i"/>
                             <constraint firstItem="cI3-ta-hDD" firstAttribute="top" secondItem="YrJ-Dj-lSo" secondAttribute="top" id="eU1-GW-k2Y"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="R7s-0B-EOi"/>
                     </view>
                     <navigationItem key="navigationItem" title="Watchlist" id="tU4-ml-AYs">
                         <barButtonItem key="leftBarButtonItem" image="Settings Off" id="lO5-G1-dOg">
@@ -3706,23 +3667,20 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <scene sceneID="3is-Cd-P8K">
             <objects>
                 <viewController storyboardIdentifier="LoadingViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="0ID-k2-iS4" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="zlB-DB-uMa"/>
-                        <viewControllerLayoutGuide type="bottom" id="aqO-A2-8kE"/>
-                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="a86-MQ-Udm">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="254.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="254.66666666666666"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="TJI-HA-yb0">
-                                <rect key="frame" x="177.5" y="117.5" width="20" height="20"/>
+                                <rect key="frame" x="177.66666666666666" y="117.33333333333333" width="20" height="19.999999999999986"/>
                             </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" red="0.10980392160000001" green="0.10980392160000001" blue="0.10980392160000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="TJI-HA-yb0" firstAttribute="centerX" secondItem="a86-MQ-Udm" secondAttribute="centerX" id="Hxr-1u-iU2"/>
+                            <constraint firstItem="TJI-HA-yb0" firstAttribute="centerX" secondItem="6O7-y4-UG3" secondAttribute="centerX" id="Hxr-1u-iU2"/>
                             <constraint firstItem="TJI-HA-yb0" firstAttribute="centerY" secondItem="a86-MQ-Udm" secondAttribute="centerY" id="NRJ-hk-rpJ"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="6O7-y4-UG3"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aMq-Rm-Igs" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -3755,7 +3713,7 @@ By using 'Popcorn Time' or accessing this site you affirm that you are either mo
         <image name="SkipForward" width="25" height="27"/>
         <image name="Star Empty" width="40" height="40"/>
         <image name="Star Full" width="40" height="40"/>
-        <image name="Subtitles" width="23.5" height="18.5"/>
+        <image name="Subtitles" width="23.666666030883789" height="18.666666030883789"/>
         <image name="Volume Maximum" width="33" height="27"/>
         <image name="Volume Minimum" width="13" height="19"/>
         <image name="Watched Indicator" width="157" height="157"/>

--- a/PopcornTime/Extensions/AppDelegate+Extension.swift
+++ b/PopcornTime/Extensions/AppDelegate+Extension.swift
@@ -151,6 +151,7 @@ extension AppDelegate: PCTPlayerViewControllerDelegate, UIViewControllerTransiti
                 
             let playViewController = storyboard.instantiateViewController(withIdentifier: "PCTPlayerViewController") as! PCTPlayerViewController
             playViewController.delegate = self
+            playViewController.modalPresentationStyle = .fullScreen
             media.play(fromFileOrMagnetLink: torrent.url, nextEpisodeInSeries: nextEpisode, loadingViewController: loadingViewController, playViewController: playViewController, progress: currentProgress, errorBlock: error, finishedLoadingBlock: finishedLoading, selectingTorrentBlock: media.title == "Unknown" ? selectTorrent : nil)
         }
     }

--- a/PopcornTime/Extensions/AppDelegate+Extension.swift
+++ b/PopcornTime/Extensions/AppDelegate+Extension.swift
@@ -96,6 +96,7 @@ extension AppDelegate: PCTPlayerViewControllerDelegate, UIViewControllerTransiti
             loadingViewController.backgroundImageView?.af_setImage(withURL: url)
         }
         loadingViewController.titleLabel.text = media.title
+        loadingViewController.modalPresentationStyle = .fullScreen
         
         self.activeRootViewController?.present(loadingViewController, animated: true)
         
@@ -158,7 +159,7 @@ extension AppDelegate: PCTPlayerViewControllerDelegate, UIViewControllerTransiti
         switch button.downloadState {
         case .downloaded:
             
-//            AppDelegate.shared.play(Movie(download.mediaMetadata) ?? Episode(download.mediaMetadata)!, torrent: Torrent()) // No torrent metadata necessary, media is loaded from disk.
+            AppDelegate.shared.play(Movie(download.mediaMetadata) ?? Episode(download.mediaMetadata)!, torrent: Torrent()) // No torrent metadata necessary, media is loaded from disk.
             
             let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet, blurStyle: .dark)
 


### PR DESCRIPTION
iOS 13's default `\.modalPresentationStyle` has changed to `.popover`, I believe theres a lot of custom Animation Transition logic that depends on the old default of `.fullscreen`. 

This is a quick fix PR to get it usable. Other issues remain, willing to keep working on fixes for those.
